### PR TITLE
Allow vkrefless netkans

### DIFF
--- a/NetKAN/t/metadata.t
+++ b/NetKAN/t/metadata.t
@@ -46,11 +46,18 @@ foreach my $shortname (sort keys %files) {
         "$shortname license ($mod_license) should match spec. Set `x_netkan_license_ok` to supress."
     );
 
-    ok(
-        $metadata->{'$kref'} || $metadata->{'$vref'},
-        "$shortname has no \$kref/\$vref field. It belongs in CKAN-meta"
-    );
-        
+    if ( defined $metadata->{'download'} ) {
+      ok(
+          ! defined $metadata->{'$kref'} && ! defined $metadata->{'$vref'},
+          "$shortname has a \$kref/\$vref and a download field, this is likely incorrect."
+      );
+    } else {
+      ok(
+          $metadata->{'$kref'} || $metadata->{'$vref'},
+          "$shortname has no \$kref/\$vref field, this is required when no download url is specified."
+      );
+    }
+
     if (my $overrides = $metadata->{x_netkan_override}) {
 
         my $is_array = ref($overrides) eq "ARRAY";
@@ -138,8 +145,6 @@ sub compare_version {
 
   $spec_version =~ s/v1\.([2|4|6])$/v1.0$1/;
   $min_version =~ s/v1\.([2|4|6])$/v1.0$1/;
-
-  print "Spec: $spec_version, Min: $min_version\n";
 
   if ($spec_version ge $min_version) {
     return 1;

--- a/NetKAN/t/metadata.t
+++ b/NetKAN/t/metadata.t
@@ -51,6 +51,10 @@ foreach my $shortname (sort keys %files) {
           ! defined $metadata->{'$kref'} && ! defined $metadata->{'$vref'},
           "$shortname has a \$kref/\$vref and a download field, this is likely incorrect."
       );
+      ok(
+          defined $metadata->{'version'},
+          "$shortname expects a version when a download url is provided."
+      );
     } else {
       ok(
           $metadata->{'$kref'} || $metadata->{'$vref'},


### PR DESCRIPTION
This change allows for NetKANs that are essentially CKANs, but will still fail when a vref/kref is provided.

Sample failures.

Partial NetKAN missing kref/vref
```
#   Failed test 'Arkas has no $kref/$vref field, this is required when no download url is specified.'
#   at t/metadata.t line 55.
# Looks like you failed 1 test of 5526.
t/metadata.t .. 
not ok 277 - Arkas has no $kref/$vref field, this is required when no download url is specified.
```
NetKAN with a Download url accidentally added
```
#   Failed test 'Arkas has a $kref/$vref and a download field, this is likely incorrect'
#   at t/metadata.t line 49.
# Looks like you failed 1 test of 5526.
t/metadata.t .. 
not ok 277 - Arkas has a $kref/$vref and a download field, this is likely incorrect
```
Full NetKAN (ex CKAN) with no version
```
#   Failed test 'Arkas requires a version if you are adding a download url.'
#   at t/metadata.t line 54.
# Looks like you failed 1 test of 5527.
t/metadata.t .. 
not ok 278 - Arkas requires a version if you are adding a download url.
```