### PR TITLE
Validate resulting ckan files against the Schema - closes #2

### DIFF
--- a/NetKAN/build.sh
+++ b/NetKAN/build.sh
@@ -10,6 +10,8 @@ KSP_NAME_DEFAULT="dummy"
 LATEST_CKAN_URL="http://ckan-travis.s3.amazonaws.com/ckan.exe"
 LATEST_NETKAN_URL="http://ckan-travis.s3.amazonaws.com/netkan.exe"
 LATEST_CKAN_META="https://github.com/KSP-CKAN/CKAN-meta/archive/master.tar.gz"
+LATEST_CKAN_VALIDATE="https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/bin/ckan-validate.py"
+LATEST_CKAN_SCHEMA="https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/CKAN.schema"
 
 # Third party utilities.
 JQ_PATH="jq"
@@ -265,6 +267,11 @@ echo "Fetching latest netkan.exe"
 wget --quiet $LATEST_NETKAN_URL -O netkan.exe
 mono netkan.exe --version
 
+# CKAN Validation files
+wget --quiet $LATEST_CKAN_VALIDATE -O ckan-validate.py
+wget --quiet $LATEST_CKAN_SCHEMA -O CKAN.schema
+chmod a+x ckan-validate.py
+
 # Fetch the latest metadata.
 echo "Fetching latest metadata"
 wget --quiet $LATEST_CKAN_META -O metadata.tar.gz
@@ -300,6 +307,7 @@ do
     fi
 
     echo "Checking $ckan"
+    ./ckan-validate.py $ckan
     echo "----------------------------------------------"
     echo ""
     cat $ckan | python -m json.tool


### PR DESCRIPTION
For some reason we've not validated our schema during testing of NetKANs and the Indexer has occasionally caught things that aren't valid. This addresses that.

```
leon@beast /tmp/NetKAN $ ./build.sh fsdaf
Using CLI argument of fsdaf
Commit hash: fsdaf
Running jsonlint on the changed files
If you get an error below you should look for syntax errors in the metadata
Validating NetKAN/DogeCoinFlag.netkan...
NetKAN/DogeCoinFlag.netkan: ok

Running basic sanity tests on metadata.
If these fail, then fix whatever is causing them first.
t/inflate.t ... skipped: Not a travis pull request
t/metadata.t .. ok      
All tests successful.
Files=2, Tests=6087,  1 wallclock secs ( 0.23 usr  0.01 sys +  0.43 cusr  0.01 csys =  0.68 CPU)
Result: PASS
Finding changes to test...
Detected file changes:
NetKAN/DogeCoinFlag.netkan

Fetching latest ckan.exe
v1.16.1-84-g944324a (beta)
Fetching latest netkan.exe
v1.16.1-84-g944324a (beta)
Fetching latest metadata
Running NetKAN for NetKAN/DogeCoinFlag.netkan
Checking built/DogeCoinFlag-v1.02.ckan                 <------ Relevant Line in log
Validating built/DogeCoinFlag-v1.02.ckan.. Success!    <------ Relevant Line in log
----------------------------------------------

{
    "abstract": "Such flag. Very currency. Wow. Meow",
    "author": "daviddwk",
    "comment": "flagmod",
    "description": "Adorn your craft with your favourite cryptocurrency. To the m\u00fcn!",
    "download": "https://github.com/pjf/DogeCoinFlag/releases/download/v1.02/DogeCoinFlag-1.02.zip",
    "download_content_type": "application/zip",
    "download_hash": {
        "sha1": "BFB78381B5565E1AC7E9B2EB9C65B76EF7F6DF71",
        "sha256": "CF70CE1F988F908FB9CF641C1E47CDA2A30D5AD951A4811A5C0C5D30F6FD3BA9"
    },
    "download_size": 53359,
    "identifier": "DogeCoinFlag",
    "ksp_version": "any",
    "license": "CC-BY",
    "name": "Dogecoin Flag",
    "resources": {
        "homepage": "https://www.reddit.com/r/dogecoin/comments/1tdlgg/i_made_a_more_accurate_dogecoin_and_a_ksp_flag/",
        "repository": "https://github.com/pjf/DogeCoinFlag"
    },
    "spec_version": 1,
    "version": "v1.02",
    "x_generated_by": "netkan"
}
----------------------------------------------

Injecting into metadata.
Injecting: built/DogeCoinFlag-v1.02.ckan
Extracted DogeCoinFlag as identifier.
Extracted any as KSP version.
Overriding any with '1.1.2'
Creating a dummy KSP '1.1.2' install
Creating /tmp/NetKAN/dummy_ksp/CKAN/downloads
Added "fsdaf" with root "/tmp/NetKAN/dummy_ksp" to known installs
Successfully set "fsdaf" as the default KSP installation
Added repository 'local' - 'file:///tmp/NetKAN/master.tar.gz'
Successfully removed "default"
Running ckan update
Downloading updates...
Updated information on 528 available modules
Running ckan install -c built/DogeCoinFlag-v1.02.ckan
About to install...

 * Dogecoin Flag v1.02

Downloading "https://github.com/pjf/DogeCoinFlag/releases/download/v1.02/DogeCoinFlag-1.02.zip" (libcurl)
0 KB/s - downloading - 0 MB left - 100%           
Installing mod "DogeCoinFlag v1.02"
Updating registry
Commiting filesystem changes
Rescanning GameData
Done!
- DogeCoinFlag v1.02
Dogecoin Flag: Such flag. Very currency. Wow. Meow

Adorn your craft with your favourite cryptocurrency. To the mün!


Module info:
- version:	v1.02
- authors:	daviddwk
- status:	stable
- license:	CC-BY

Provides:
- DogeCoinFlag

Resources:
- homepage: https://www.reddit.com/r/dogecoin/comments/1tdlgg/i_made_a_more_accurate_dogecoin_and_a_ksp_flag/
- repository: https://github.com/pjf/DogeCoinFlag

Filename: 6F8BEBCB-DogeCoinFlag-v1.02.zip

Showing 3 installed files:
- GameData/DogeCoinFlag
- GameData/DogeCoinFlag/Flags
- GameData/DogeCoinFlag/Flags/dogecoin.png
Successfully removed "fsdaf"
```