### PR TITLE
Skip Testing Frozen

### DIFF
--- a/NetKAN/build.sh
+++ b/NetKAN/build.sh
@@ -229,7 +229,7 @@ echo "If you get an error below you should look for syntax errors in the metadat
 
 for f in $COMMIT_CHANGES
 do
-    if [[ "$f" =~ build.sh|metadata.t ]]
+    if [[ "$f" =~ .frozen$ ]]
     then
         echo "Lets try not to validate '$f' with jsonlint"
         continue
@@ -301,7 +301,7 @@ fi
 # Note: Additional NETKAN_OPTIONS may be set on jenkins jobs
 for f in $COMMIT_CHANGES
 do
-    if [[ "$f" =~ build.sh|metadata.t ]];then
+    if [[ "$f" =~ .frozen$ ]];then
         echo "Lets try not to build '$f' with netkan"
         continue
     fi


### PR DESCRIPTION
This skips testing frozen files, replaces skipping metadata/build which are no longer in the NetKAN repo