### PR TITLE
Add KSP 1.3.8 override to build.sh

### DIFF
--- a/CKAN-meta/build.sh
+++ b/CKAN-meta/build.sh
@@ -81,6 +81,10 @@ create_dummy_ksp () {
         echo "Overriding '1.3' with '$KSP_VERSION_DEFAULT'"
         KSP_VERSION=$KSP_VERSION_DEFAULT
         ;;
+    "1.3.8")
+        echo "Overriding '1.3.8' with '$KSP_VERSION_DEFAULT'"
+        KSP_VERSION=$KSP_VERSION_DEFAULT
+        ;;
     "1.3.9")
         echo "Overriding '1.3.9' with '$KSP_VERSION_DEFAULT'"
         KSP_VERSION=$KSP_VERSION_DEFAULT

--- a/NetKAN/build.sh
+++ b/NetKAN/build.sh
@@ -90,6 +90,10 @@ create_dummy_ksp () {
         echo "Overriding '1.3' with '$KSP_VERSION_DEFAULT'"
         KSP_VERSION=$KSP_VERSION_DEFAULT
         ;;
+    "1.3.8")
+        echo "Overriding '1.3.8' with '$KSP_VERSION_DEFAULT'"
+        KSP_VERSION=$KSP_VERSION_DEFAULT
+        ;;
     "1.3.9")
         echo "Overriding '1.3.9' with '$KSP_VERSION_DEFAULT'"
         KSP_VERSION=$KSP_VERSION_DEFAULT


### PR DESCRIPTION
I've noticed a couple of mods setting their max version to 1.3.8 (I suppose they want to make sure they don't get caught by a beta for 1.4)