### PR TITLE
Support license arrays

### DIFF
--- a/NetKAN/t/metadata.t
+++ b/NetKAN/t/metadata.t
@@ -43,10 +43,19 @@ foreach my $shortname (sort keys %files) {
     my $kref = $metadata->{'$kref'} // "(none)";
 
     if ( $kref !~ /^\#\/ckan\/netkan/ ) {
-      ok(
-          $metadata->{x_netkan_license_ok} || $licenses{$mod_license},
-          "$shortname license ($mod_license) should match spec. Set `x_netkan_license_ok` to supress."
-      );
+        if (ref($mod_license) eq "ARRAY") {
+            foreach my $lic (@{$mod_license}) {
+                ok(
+                    $metadata->{x_netkan_license_ok} || $licenses{$lic},
+                    "$shortname license ($lic) should match spec. Set `x_netkan_license_ok` to supress."
+                );
+            }
+        } else {
+            ok(
+                $metadata->{x_netkan_license_ok} || $licenses{$mod_license},
+                "$shortname license ($mod_license) should match spec. Set `x_netkan_license_ok` to supress."
+            );
+        }
     }
 
     if ( defined $metadata->{'download'} ) {
@@ -89,7 +98,7 @@ foreach my $shortname (sort keys %files) {
 
     my $spec_version = $metadata->{spec_version};
     ok(
-        $spec_version =~ m/^1$|^v\d\.\d\d?$/, 
+        $spec_version =~ m/^1$|^v\d\.\d\d?$/,
         "spec version must be 1 or in the 'vX.X' format"
     );
 
@@ -166,7 +175,7 @@ foreach my $shortname (sort keys %files) {
     }
 }
 
-# 1.10 is < 1.2 our number comparisons don't work now :( 
+# 1.10 is < 1.2 our number comparisons don't work now :(
 # TODO: Do something better than this quick hack
 sub compare_version {
   my ($spec_version, $min_version) = @_;


### PR DESCRIPTION
https://github.com/KSP-CKAN/NetKAN/pull/6038 is erroring out:

```
Running basic sanity tests on metadata.
If these fail, then fix whatever is causing them first.
t/inflate.t ... skipped: Not a travis pull request

#   Failed test 'HeatControl license (ARRAY(0x284abd8)) should match spec. Set `x_netkan_license_ok` to supress.'
#   at t/metadata.t line 45.
# Looks like you failed 1 test of 11013.
t/metadata.t .. 
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/11013 subtests 
```

The spec allows `license` to be an array:

https://github.com/KSP-CKAN/CKAN/blob/8cfc18a6695bb6755488b67885cc1fa416bb5592/CKAN.schema#L400-L410

But the Jenkins script doesn't. This pull request adds that.