### PR TITLE
Replace version comparison quick hack

### DIFF
--- a/NetKAN/t/metadata.t
+++ b/NetKAN/t/metadata.t
@@ -5,6 +5,7 @@ use autodie;
 use strict;
 use Test::Most;
 use Test::NetKAN qw(netkan_files read_netkan licenses);
+use Perl::Version;
 
 use Data::Dumper;
 
@@ -175,19 +176,9 @@ foreach my $shortname (sort keys %files) {
     }
 }
 
-# 1.10 is < 1.2 our number comparisons don't work now :(
-# TODO: Do something better than this quick hack
 sub compare_version {
   my ($spec_version, $min_version) = @_;
-
-  $spec_version =~ s/v1\.([2|4|6])$/v1.0$1/;
-  $min_version =~ s/v1\.([2|4|6])$/v1.0$1/;
-
-  if ($spec_version ge $min_version) {
-    return 1;
-  } else {
-    return 0;
-  }
+  return Perl::Version->new($spec_version) >= Perl::Version->new($min_version);
 }
 
 done_testing;

--- a/ckan-ci/Dockerfile
+++ b/ckan-ci/Dockerfile
@@ -4,5 +4,5 @@ USER root
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 ADD mono-official.list /etc/apt/sources.list.d/
-RUN apt-get update && apt-get install -y mono-complete jq python-demjson libjson-any-perl libtest-most-perl libipc-system-simple-perl libwww-mechanize-perl python-jsonschema
+RUN apt-get update && apt-get install -y mono-complete jq python-demjson libjson-any-perl libtest-most-perl libipc-system-simple-perl libwww-mechanize-perl libperl-version-perl python-jsonschema
 ADD .ssh /home/jenkins/.ssh


### PR DESCRIPTION
There's a TODO in the NetKAN Jenkins script regarding how we confirm that a spec version is correct. In order to properly compare "v1.2" and "v1.10", it performs a string substitution that turns "v1.2" into "v1.02".

The `Perl::Version` module handles this correctly in my testing; full sort of some sample values:
```
v0.0.1, v0.1.1, 0.9.1, 1, 1.0, v1.0, 1.2, v1.2, 1.2.1, 1.10, v1.10, v2.1.1
```