### PR TITLE
Support frozen modules in CKAN-meta

### DIFF
--- a/CKAN-meta/build.sh
+++ b/CKAN-meta/build.sh
@@ -272,6 +272,12 @@ do
     cat $ckan | python -m json.tool
     echo ----------------------------------------------
 
+    if [[ "$ckan" =~ .frozen$ ]]
+    then
+        echo "Skipping install of frozen module '$ckan'"
+        continue
+    fi
+
     # Extract identifier and KSP version.
     CURRENT_IDENTIFIER=$($JQ_PATH '.identifier' $ckan)
     CURRENT_KSP_VERSION=$($JQ_PATH 'if .ksp_version then .ksp_version else .ksp_version_max end' $ckan)


### PR DESCRIPTION
## Problems

KSP-CKAN/CKAN#2261 pointed out invalid JSON in some .frozen CKAN-meta files. When KSP-CKAN/CKAN-meta#1319 fixed it, the Travis script tried to install them, which failed on the download because the module is no longer available for download, hence being frozen.

## Changes

Now the script will not try to install frozen modules, but they will still have their syntax validated. This is done by borrowing the NetKAN script's .frozen check and updating the message.