### PR TITLE
Add CC-BY-ND licenses

### DIFF
--- a/NetKAN/t/lib/Test/NetKAN.pm
+++ b/NetKAN/t/lib/Test/NetKAN.pm
@@ -59,7 +59,7 @@ are all merely '1' (true).
 
 sub licenses {
     my %licenses;
-    
+
     # Populate our hash with the fields shamelessly torn from
     # CKAN.schema
     @licenses{
@@ -76,6 +76,7 @@ sub licenses {
         "CC-BY-NC", "CC-BY-NC-1.0", "CC-BY-NC-2.0", "CC-BY-NC-2.5", "CC-BY-NC-3.0", "CC-BY-NC-4.0",
         "CC-BY-NC-SA", "CC-BY-NC-SA-1.0", "CC-BY-NC-SA-2.0", "CC-BY-NC-SA-2.5", "CC-BY-NC-SA-3.0", "CC-BY-NC-SA-4.0",
         "CC-BY-NC-ND", "CC-BY-NC-ND-1.0", "CC-BY-NC-ND-2.0", "CC-BY-NC-ND-2.5", "CC-BY-NC-ND-3.0", "CC-BY-NC-ND-4.0",
+        "CC-BY-ND", "CC-BY-ND-1.0", "CC-BY-ND-2.0", "CC-BY-ND-2.5", "CC-BY-ND-3.0", "CC-BY-ND-4.0",
         "CC0",
         "CDDL", "CPL",
         "EFL-1.0", "EFL-2.0",


### PR DESCRIPTION
KSP-CKAN/CKAN#2160, which seems to have disappeared somehow, added CC-BY-ND licenses to CKAN.schema. However, the code dealing with licenses was not updated.

This pull request updates the licenses listed in the pull request validation scripts.