### PR TITLE
Simulate installed DLC for KSP 1.4.0 and later

### DIFF
--- a/CKAN-meta/build.sh
+++ b/CKAN-meta/build.sh
@@ -54,7 +54,16 @@ create_dummy_ksp () {
     #       it will be auto-created as a plain directory!
     ln -s --verbose ../../downloads_cache/ dummy_ksp/CKAN/downloads
 
+    # Set the base game version
     echo "Version $KSP_VERSION" > dummy_ksp/readme.txt
+
+    # Simulate the DLC if base game version 1.4.0 or later
+    if versions_less_or_equal 1.4.0 "$KSP_VERSION"
+    then        
+        mkdir --p --verbose \
+            dummy_ksp/GameData/SquadExpansion/MakingHistory
+        echo "Version 1.1.0" > dummy_ksp/GameData/SquadExpansion/MakingHistory/readme.txt
+    fi
 
     # Copy in resources.
     cp --verbose ckan.exe dummy_ksp/ckan.exe

--- a/NetKAN/build.sh
+++ b/NetKAN/build.sh
@@ -63,7 +63,16 @@ create_dummy_ksp () {
     #       it will be auto-created as a plain directory!
     ln -s --verbose ../../downloads_cache/ dummy_ksp/CKAN/downloads
 
+    # Set the base game version
     echo "Version $KSP_VERSION" > dummy_ksp/readme.txt
+
+    # Simulate the DLC if base game version 1.4.0 or later
+    if versions_less_or_equal 1.4.0 "$KSP_VERSION"
+    then
+        mkdir --p --verbose \
+            dummy_ksp/GameData/SquadExpansion/MakingHistory
+        echo "Version 1.1.0" > dummy_ksp/GameData/SquadExpansion/MakingHistory/readme.txt
+    fi
 
     # Copy in resources.
     cp --verbose ckan.exe dummy_ksp/ckan.exe


### PR DESCRIPTION
## Background

The pull request validation scripts for NetKAN and CKAN-meta set up "dummy" KSP installs when testing installation of a mod.

Current versions of CKAN make a special module name `MakingHistory-DLC` available if a file is found at `GameData/SquadExpansion/MakingHistory/readme.txt`.

## Problem

Currently mods depending on `MakingHistory-DLC` always fail validation, because the required file doesn't exist in the dummy install. See KSP-CKAN/NetKAN#6473.

## Changes

Now we generate `GameData/SquadExpansion/MakingHistory/readme.txt` if the designated base game version is 1.4.0 or later. This should allow mods dependent on the DLC to install properly.

Note that the version in the file is hard coded to 1.1.0, current as of this writing. We have no system for tracking real DLC versions like we do for the base game in `builds.json`, but people probably won't use old versions of the DLC on purpose anyway. We can return to this if DLC versions become important in the future.