### PR TITLE
Catch invalid game version

### DIFF
--- a/CKAN-meta/build.sh
+++ b/CKAN-meta/build.sh
@@ -12,6 +12,7 @@ JQ_PATH="jq"
 
 # Return codes.
 EXIT_OK=0
+EXIT_FAILED_NO_GAME_VERSION=5
 
 # Allow us to specify a commit id as the first argument
 if [ -n "$1" ]
@@ -335,6 +336,12 @@ do
     # Extract identifier and KSP version.
     CURRENT_IDENTIFIER=$($JQ_PATH --raw-output '.identifier' $ckan)
     CURRENT_KSP_VERSION=$(ckan_max_real_version "$ckan")
+
+    if [[ -z $CURRENT_KSP_VERSION ]]
+    then
+        echo "$ckan doesn't match any valid game version"
+        exit $EXIT_FAILED_NO_GAME_VERSION
+    fi
 
     # TODO: Someday we could loop over ( $(ckan_matching_versions "$ckan") ) to find
     #       working versions less than the maximum, if the maximum doesn't work.

--- a/NetKAN/build.sh
+++ b/NetKAN/build.sh
@@ -21,6 +21,7 @@ EXIT_FAILED_PROVE_STEP=1
 EXIT_FAILED_JSON_VALIDATION=2
 EXIT_FAILED_ROOT_NETKANS=3
 EXIT_FAILED_DUPLICATE_IDENTIFIERS=4
+EXIT_FAILED_NO_GAME_VERSION=5
 
 # Allow us to specify a commit id as the first argument
 if [ -n "$1" ]
@@ -441,6 +442,12 @@ do
     # Extract identifier and KSP version.
     CURRENT_IDENTIFIER=$($JQ_PATH --raw-output '.identifier' $ckan)
     CURRENT_KSP_VERSION=$(ckan_max_real_version "$ckan")
+
+    if [[ -z $CURRENT_KSP_VERSION ]]
+    then
+        echo "$ckan doesn't match any valid game version"
+        exit $EXIT_FAILED_NO_GAME_VERSION
+    fi
 
     # TODO: Someday we could loop over ( $(ckan_matching_versions "$ckan") ) to find
     #       working versions less than the maximum, if the maximum doesn't work.


### PR DESCRIPTION
## Problem

If you choose a `ksp_version` that doesn't match any actual game version, as in KSP-CKAN/NetKAN#6861:

```json
	    "ksp_version"  : "1.5.9",
```

... then the validation script's errors aren't very clear:

```
Extracted  as KSP version.
```

```
removed '/home/jenkins/.mono/registry/CurrentUser/software/ckan/values.xml'
add <name> <path> - argument missing, perhaps you forgot it?
Build step 'Execute shell' marked build as failure
```

## Cause

`ckan_max_real_versions` can return the empty string if no real versions match the generated metadata, but there's no validation to handle this possibility:

https://github.com/KSP-CKAN/xKAN-meta_testing/blob/36ccd470cde1c6a02a8a3fc267e2eddad2b6640c/NetKAN/build.sh#L441-L450

## Changes

Now if `$CURRENT_KSP_VERSION` is null, we print a more descriptive error and exit with a failure code.

The scripts for both NetKAN and CKAN-meta are updated.