### PR TITLE
Switch to built in dummy creation command and set compatible versions

### DIFF
--- a/CKAN-meta/build.sh
+++ b/CKAN-meta/build.sh
@@ -12,6 +12,7 @@ JQ_PATH="jq"
 
 # Return codes.
 EXIT_OK=0
+EXIT_FAILED_NO_GAME_VERSION=5
 
 # Allow us to specify a commit id as the first argument
 if [ -n "$1" ]
@@ -22,67 +23,48 @@ fi
 
 # ------------------------------------------------
 # Function for creating dummy KSP directories to
-# test on. Takes version as an argument.
+# test on.
+# Usage: create_dummy_ksp name main_ver ver2 ver3 ...
 # ------------------------------------------------
-create_dummy_ksp () {
-    # Set the version to the requested KSP version
+create_dummy_ksp() {
+    KSP_NAME="$1"
+    shift
     KSP_VERSION="$1"
-    KSP_NAME="$2"
+    shift
+    COMPAT_VERSIONS=("$@")
 
     echo "Creating a dummy KSP '$KSP_VERSION' install"
 
     # Remove any existing KSP dummy install.
-    if [ -d "dummy_ksp/" ]
+    if [[ -d dummy_ksp/ ]]
     then
         rm -rf dummy_ksp
     fi
 
-    # Create a new dummy KSP.
-    mkdir -p --verbose \
-        dummy_ksp \
-        dummy_ksp/CKAN \
-        dummy_ksp/GameData \
-        dummy_ksp/Ships/ \
-        dummy_ksp/Ships/VAB \
-        dummy_ksp/Ships/SPH \
-        dummy_ksp/Ships/@thumbs \
-        dummy_ksp/Ships/@thumbs/VAB \
-        dummy_ksp/Ships/@thumbs/SPH
+    # Create dummy install.
+    mono ckan.exe ksp fake --set-default "$KSP_NAME" dummy_ksp "$KSP_VERSION" 1.1.0
 
-    # Link to the shared downloads cache.
-    # NOTE: If this isn't done before ckan.exe uses the instance,
-    #       it will be auto-created as a plain directory!
+    # Add other compatible versions.
+    for compVer in "${COMPAT_VERSIONS[@]}"
+    do
+        mono ckan.exe compat add "$compVer"
+    done
+
+    # Link to the netkan downloads cache as a legacy cache.
     ln -s --verbose ../../downloads_cache/ dummy_ksp/CKAN/downloads
-
-    # Set the base game version
-    echo "Version $KSP_VERSION" > dummy_ksp/readme.txt
-
-    # Simulate the DLC if base game version 1.4.0 or later
-    if versions_less_or_equal 1.4.0 "$KSP_VERSION"
-    then
-        mkdir --p --verbose \
-            dummy_ksp/GameData/SquadExpansion/MakingHistory
-        echo "Version 1.1.0" > dummy_ksp/GameData/SquadExpansion/MakingHistory/readme.txt
-    fi
 
     # Copy in resources.
     cp --verbose ckan.exe dummy_ksp/ckan.exe
 
     # Reset the Mono registry.
-    if [ "$USER" = "jenkins" ]
+    if [[ "$USER" = "jenkins" ]]
     then
         REGISTRY_FILE="$HOME"/.mono/registry/CurrentUser/software/ckan/values.xml
-        if [ -r "$REGISTRY_FILE" ]
+        if [[ -r "$REGISTRY_FILE" ]]
         then
             rm -f --verbose "$REGISTRY_FILE"
         fi
     fi
-
-    # Register the new dummy install.
-    mono ckan.exe ksp add "$KSP_NAME" "`pwd`/dummy_ksp"
-
-    # Set the instance to default.
-    mono ckan.exe ksp default "$KSP_NAME"
 
     # Point to the local metadata instead of GitHub.
     mono ckan.exe repo add local "file://`pwd`/master.tar.gz"
@@ -240,16 +222,18 @@ ckan_matching_versions() {
 }
 
 # ------------------------------------------------
-# Print max real version compatible with given .ckan file.
-# Even if you claim compatibility with 99.99.99, this
-# will only return the most recent release.
+# Print versions indicated in pull request body text.
+# Input comes from the Jenkins ghprbPullLongDescription environment variable.
+# We look for a string that looks like:
+#   ckan compat add 1.4 1.5 1.6
+# And we print out the version numbers that we find.
 # ------------------------------------------------
-ckan_max_real_version() {
-    # Usage: ckan_max_real_version modname-version.ckan
-    CKAN="$1"
-
-    VERS=( $(ckan_matching_versions "$CKAN") )
-    echo "${VERS[0]}"
+versions_from_description() {
+    if [[ $ghprbPullLongDescription =~ 'ckan compat add'((' '[0-9.]+)+) ]]
+    then
+        # Unquoted so each version is a separate string
+        echo ${BASH_REMATCH[1]}
+    fi
 }
 
 declare -a VERSIONS
@@ -323,7 +307,7 @@ do
 
     ./ckan-validate.py "$ckan"
     echo ----------------------------------------------
-    cat "$ckan" | python -m json.tool
+    cat "$ckan"
     echo ----------------------------------------------
 
     if [[ "$ckan" =~ .frozen$ ]]
@@ -334,14 +318,16 @@ do
 
     # Extract identifier and KSP version.
     CURRENT_IDENTIFIER=$($JQ_PATH --raw-output '.identifier' "$ckan")
-    CURRENT_KSP_VERSION=$(ckan_max_real_version "$ckan")
+    KSP_VERSIONS=( $(ckan_matching_versions "$ckan") $(versions_from_description) )
 
-    # TODO: Someday we could loop over ( $(ckan_matching_versions "$ckan") ) to find
-    #       working versions less than the maximum, if the maximum doesn't work.
-    #       (E.g., a dependency isn't updated yet.)
+    if (( ${#KSP_VERSIONS[@]} < 1 ))
+    then
+        echo "$ckan doesn't match any valid game version"
+        exit "$EXIT_FAILED_NO_GAME_VERSION"
+    fi
 
     echo "Extracted $CURRENT_IDENTIFIER as identifier."
-    echo "Extracted $CURRENT_KSP_VERSION as KSP version."
+    echo "Extracted ${KSP_VERSIONS[*]} as KSP versions."
 
     # Get a list of all the OTHER files.
     OTHER_FILES=()
@@ -359,7 +345,7 @@ do
     inject_metadata $OTHER_FILES
 
     # Create a dummy KSP install.
-    create_dummy_ksp "$CURRENT_KSP_VERSION" "$ghprbActualCommit"
+    create_dummy_ksp "$ghprbActualCommit" "${KSP_VERSIONS[@]}"
 
     echo "Running ckan update"
     mono ckan.exe update


### PR DESCRIPTION
## Standardize dummy game folder creation

KSP-CKAN/CKAN#2627 and KSP-CKAN/CKAN#2642 created a new `ckan ksp fake` command to create dummy game folders, in part influenced by how the validation scripts do it.

Now the NetKAN and CKAN-meta validation scripts are updated to use this command, and the steps that were redundant with it are removed.

## Set compatible versions based on mod's compatibility

The validation scripts attempt to install each affected mod to make sure everything is OK. This can fail if some of the dependencies aren't marked as compatible with the game version of the dummy folder we create. However, this can be a false negative if a mod can be installed on several versions, since the dependencies may be available in previous versions.

Now when a mod uses `ksp_version_min` and/or `ksp_version_max` to indicate compatibility with a range of game versions, we add all of those game versions to the dummy folder's compatible list with `ckan compat add` commands. This will ensure that if a mod's dependencies are available on *any* of its compatible versions, then its installation will succeed.

## Set compatible versions based on pull request body text

Sometimes it may be useful to have a manual override for the compatible versions. For example, a mod's installation may fail due to dependencies that are not compatible with any of its versions, but which we expect to be updated soon. Or users of a mod may already rely on `ckan compat` to install such dependencies (I suspect this may become commonplace given how compatible KSP 1.4, 1.5, and 1.6 have proven to be).

Now if such a situation arises, we can add a string like this to the description of a NetKAN or CKAN-meta pull request:

```
ckan compat add 1.2.2 1.3 1.4 1.5.1
```

... and the indicated versions will be added to the compatible game versions of the dummy installs used to validate that pull request. So if we submit a pull request and it errors out with a dependency, we can add an override to the PR text and do a rebuild to see whether there are any other problems with the PR.

Please share any feedback about the format of the override, especially if there's an existing convention for this kind of thing. I didn't know of any, so I borrowed the format of the underlying command for memorability.

## Better error if no game versions are compatible

If you choose a `ksp_version` that doesn't match any actual game version, as in KSP-CKAN/NetKAN#6861:

```json
	    "ksp_version"  : "1.5.9",
```

... then the validation script's errors aren't very clear:

```
Extracted  as KSP version.
```

```
removed '/home/jenkins/.mono/registry/CurrentUser/software/ckan/values.xml'
add <name> <path> - argument missing, perhaps you forgot it?
Build step 'Execute shell' marked build as failure
```

Now we print a more descriptive error and exit with a failure code.

(This part replaces #42, which would have conflicted with the above changes about setting additional compatible versions. This way we don't have to resolve conflicts in git.)

## JSON output

The validation script output pipes the .ckan file contents through `python -m json.tool`, which is unnecessary because generated .ckan files are already pretty printed. In fact, netkan's output is better, because it has code to sort the properties in a useful way, whereas `json.tool` only sorts them alphabetically.

Now this line just prints the file as-is.