### PR TITLE
Check that spec_version >= 1.26 for `any_of`

### DIFF
--- a/NetKAN/t/metadata.t
+++ b/NetKAN/t/metadata.t
@@ -174,6 +174,24 @@ foreach my $shortname (sort keys %files) {
             );
         }
     }
+
+    foreach my $relgroup (grep { defined } (
+        $metadata->{depends},
+        $metadata->{recommends},
+        $metadata->{suggests},
+        $metadata->{supports},
+        $metadata->{conflicts}
+    )) {
+        foreach my $rel (@{$relgroup}) {
+            if ($rel->{any-of}) {
+                ok(
+                    compare_version($spec_version, "v1.26"),
+                    "$shortname - spec_version v1.26+ required for 'any-of'"
+                );
+            }
+        }
+    }
+
 }
 
 sub compare_version {

--- a/NetKAN/t/metadata.t
+++ b/NetKAN/t/metadata.t
@@ -183,10 +183,10 @@ foreach my $shortname (sort keys %files) {
         $metadata->{conflicts}
     )) {
         foreach my $rel (@{$relgroup}) {
-            if ($rel->{any-of}) {
+            if ($rel->{any_of}) {
                 ok(
                     compare_version($spec_version, "v1.26"),
-                    "$shortname - spec_version v1.26+ required for 'any-of'"
+                    "$shortname - spec_version v1.26+ required for 'any_of'"
                 );
             }
         }


### PR DESCRIPTION
KSP-CKAN/CKAN#2660 is adding an `any_of` option for dependencies, which requires a spec/schema update. If this is merged, then we will want to make sure that `spec_version` is at least 1.26 for any metadata that uses it. This pull request adds that check.