### PR TITLE
Require spec_version v1.26+ for replaced_by

### DIFF
--- a/NetKAN/t/metadata.t
+++ b/NetKAN/t/metadata.t
@@ -124,6 +124,13 @@ foreach my $shortname (sort keys %files) {
         );
     }
 
+    if ($metadata->{replaced_by}) {
+        ok(
+            compare_version($spec_version, "v1.26"),
+            "$shortname - spec_version v1.26+ required for 'replaced_by'"
+        );
+    }
+
     foreach my $install (@{$metadata->{install}}) {
         if ($install->{install_to} =~ m{^GameData/}) {
             ok(


### PR DESCRIPTION
KSP-CKAN/CKAN#2671 added a `replaced_by` metadata property in spec version 1.26.

KSP-CKAN/NetKAN#7048 is adding that property to a module that uses `spec_version` v1.4, which should report an error, but it succeeds instead.

This pull request adds that check.