### PR TITLE
Don't require name in any_of relationships

### DIFF
--- a/NetKAN/t/metadata.t
+++ b/NetKAN/t/metadata.t
@@ -30,13 +30,29 @@ foreach my $shortname (sort keys %files) {
         "$shortname: CKAN identifiers must consist only of letters, numbers, and dashes, and must start with a letter or number."
     );
 
-    foreach my $relation (qw(depends recommends suggests conflicts)) {
-        foreach my $mod (@{$metadata->{$relation}}) {
-            like(
-                $mod->{name},
-                $ident_qr,
-                "$shortname: $mod->{name} in $relation is not a valid CKAN identifier"
-            );
+    my $spec_version = $metadata->{spec_version};
+
+    foreach my $relation (qw(depends recommends suggests conflicts supports)) {
+        foreach my $rel (@{$metadata->{$relation}}) {
+            if ($rel->{any_of}) {
+                ok(
+                    compare_version($spec_version, "v1.26"),
+                    "$shortname - spec_version v1.26+ required for 'any_of'"
+                );
+                foreach my $mod ($rel->{any_of}) {
+                    like(
+                        $mod->{name},
+                        $ident_qr,
+                        "$shortname: $mod->{name} in $relation any_of is not a valid CKAN identifier"
+                    );
+                }
+            } else {
+                like(
+                    $rel->{name},
+                    $ident_qr,
+                    "$shortname: $rel->{name} in $relation is not a valid CKAN identifier"
+                );
+            }
         }
     }
 
@@ -97,7 +113,6 @@ foreach my $shortname (sort keys %files) {
         }
     }
 
-    my $spec_version = $metadata->{spec_version};
     ok(
         $spec_version =~ m/^1$|^v\d\.\d\d?$/,
         "spec version must be 1 or in the 'vX.X' format"
@@ -172,23 +187,6 @@ foreach my $shortname (sort keys %files) {
                 compare_version($spec_version,"v1.18"),
                 "$shortname - spec_version v1.18+ required for 'as'"
             );
-        }
-    }
-
-    foreach my $relgroup (grep { defined } (
-        $metadata->{depends},
-        $metadata->{recommends},
-        $metadata->{suggests},
-        $metadata->{supports},
-        $metadata->{conflicts}
-    )) {
-        foreach my $rel (@{$relgroup}) {
-            if ($rel->{any_of}) {
-                ok(
-                    compare_version($spec_version, "v1.26"),
-                    "$shortname - spec_version v1.26+ required for 'any_of'"
-                );
-            }
         }
     }
 


### PR DESCRIPTION
## Problem

KSP-CKAN/NetKAN#7067 is updating a netkan to use an `any_of` relationship, see KSP-CKAN/CKAN#2660. It's getting this error:

https://ci.ksp-ckan.space/job/NetKAN/8105/console

```
Use of uninitialized value in concatenation (.) or string at t/metadata.t line 37.

#   Failed test 'PoodsCalmNebulaSkybox:  in depends is not a valid CKAN identifier'
#   at t/metadata.t line 37.
#                   undef
#     doesn't match '(?^:^[A-Za-z0-9-]+$)'
Use of uninitialized value in concatenation (.) or string at t/metadata.t line 37.

#   Failed test 'PoodsDeepStarMap:  in depends is not a valid CKAN identifier'
#   at t/metadata.t line 37.
#                   undef
#     doesn't match '(?^:^[A-Za-z0-9-]+$)'
Use of uninitialized value in concatenation (.) or string at t/metadata.t line 37.

#   Failed test 'PoodsMilkyWaySkybox:  in depends is not a valid CKAN identifier'
#   at t/metadata.t line 37.
#                   undef
#     doesn't match '(?^:^[A-Za-z0-9-]+$)'
# Looks like you failed 3 tests of 13180.
t/metadata.t .. 
Dubious, test returned 3 (wstat 768, 0x300)
Failed 3/13180 subtests 
```

## Cause

This check assumes every relationship will have a `name` property. That's not the case if `any_of` is used.

https://github.com/KSP-CKAN/xKAN-meta_testing/blob/771a6132beeca3e6910bcf69303d29cff26a3e41/NetKAN/t/metadata.t#L33-L41

## Changes

Now the `any_of` check from #45 is moved up and merged with the older relationship check, such that we only look for a `name` property when `any_of` isn't present.

In addition, we now check that the child nodes of `any_of` also have `name`. And `supports` relationships are added to the loop.