### PR TITLE
Validate renamed netkans

### DIFF
--- a/NetKAN/build.sh
+++ b/NetKAN/build.sh
@@ -271,7 +271,7 @@ VERSIONS=( $(get_versions) )
 if [ -n "$ghprbActualCommit" ]
 then
     echo "Commit hash: $ghprbActualCommit"
-    export COMMIT_CHANGES="`git diff --diff-filter=AM --name-only --stat origin/master...HEAD`"
+    export COMMIT_CHANGES="`git diff --diff-filter=AMR --name-only --stat origin/master...HEAD`"
 else
     echo "No commit provided, skipping further tests."
     exit "$EXIT_OK"


### PR DESCRIPTION
## Problem

When KSP-CKAN/NetKAN#7222 moved `NetKAN/Kopernicus-Backport.netkan` to `NetKAN/Backports/Kopernicus.netkan`, the file was not validated. It should have been (and based on my testing, it would have passed).

Same thing happened in KSP-CKAN/NetKAN#7272; no validation occurred even though we were re-enabling a .netkan file.

## Cause

This line prints files that were added (A) or modified (M), and excludes files that were renamed:

https://github.com/KSP-CKAN/xKAN-meta_testing/blob/7c1b426111525c9884b989f0b91dd6834ad00f77/NetKAN/build.sh#L274

## Changes

The `git diff` command that we use to find changed netkans is updated to include renames, as was already done for CKAN-meta in 2449a8f5ae87177afda5f35f38a1397f03e2dd59. This was the reason that `NetKAN/Backports/Kopernicus.netkan` was not run through netkan.exe.
