### PR TITLE
Update 'ckan ksp fake' syntax for dummy instances

### DIFF
--- a/CKAN-meta/build.sh
+++ b/CKAN-meta/build.sh
@@ -52,7 +52,16 @@ create_dummy_ksp() {
     fi
 
     # Create dummy install.
-    mono ckan.exe ksp fake --set-default --headless "$KSP_NAME" dummy_ksp "$KSP_VERSION" 1.1.0
+    # The DLCs are simulated depending on the version.
+    if versions_less_or_equal "1.7.1" "$KSP_VERSION"
+    then
+        mono ckan.exe ksp fake --set-default --headless "$KSP_NAME" dummy_ksp "$KSP_VERSION" --MakingHistory 1.1.0 --BreakingGround 1.0.0
+    elif versions_less_or_equal "1.4.1" "$KSP_VERSION"
+    then
+        mono ckan.exe ksp fake --set-default --headless "$KSP_NAME" dummy_ksp "$KSP_VERSION" --MakingHistory 1.1.0
+    else
+        mono ckan.exe ksp fake --set-default --headless "$KSP_NAME" dummy_ksp "$KSP_VERSION"
+    fi
 
     # Add other compatible versions.
     for compVer in "${COMPAT_VERSIONS[@]}"

--- a/NetKAN/build.sh
+++ b/NetKAN/build.sh
@@ -61,7 +61,16 @@ create_dummy_ksp() {
     fi
 
     # Create dummy install.
-    mono ckan.exe ksp fake --set-default --headless "$KSP_NAME" dummy_ksp "$KSP_VERSION" 1.1.0
+    # The DLCs are simulated depending on the version.
+    if versions_less_or_equal "1.7.1" "$KSP_VERSION"
+    then
+        mono ckan.exe ksp fake --set-default --headless "$KSP_NAME" dummy_ksp "$KSP_VERSION" --MakingHistory 1.1.0 --BreakingGround 1.0.0
+    elif versions_less_or_equal "1.4.1" "$KSP_VERSION"
+    then
+        mono ckan.exe ksp fake --set-default --headless "$KSP_NAME" dummy_ksp "$KSP_VERSION" --MakingHistory 1.1.0
+    else
+        mono ckan.exe ksp fake --set-default --headless "$KSP_NAME" dummy_ksp "$KSP_VERSION"
+    fi
 
     # Add other compatible versions.
     for compVer in "${COMPAT_VERSIONS[@]}"


### PR DESCRIPTION
Needed for https://github.com/KSP-CKAN/CKAN/pull/2773.

**Wait with merge until 2773 is merged too.**

2773 changes the syntax of `ckan ksp fake` to a more future proof one (hopefully...).
Also it CKAN will throw an error if a faked DLC is requested but the KSP version is too low.
The fact that there was now error thrown was used by the scripts, but it won't work anymore. So a version comparison is needed to decide whether to fake a DLC or not.