### PR TITLE
Let netkan validation print directly to stdout

### DIFF
--- a/CKAN-meta/build.sh
+++ b/CKAN-meta/build.sh
@@ -321,16 +321,7 @@ do
 
     echo "Validating metadata: '$ckan'"
     # Note: Additional NETKAN_OPTIONS may be set on jenkins jobs
-    OUTPUT=$(mono netkan.exe --validate-ckan "$ckan" $NETKAN_OPTIONS)
-    if (( $? != 0 ))
-    then
-        # Print error and quit
-        echo "$OUTPUT"
-        exit $EXIT_NETKAN_VALIDATION_FAILED
-    fi
-    echo ----------------------------------------------
-    cat "$ckan"
-    echo ----------------------------------------------
+    mono netkan.exe --validate-ckan "$ckan" $NETKAN_OPTIONS
 
     # Extract identifier and KSP version.
     CURRENT_IDENTIFIER=$($JQ_PATH --raw-output '.identifier' "$ckan")


### PR DESCRIPTION
In #52 we set up the CKAN-meta PR script to validate its input files with `netkan.exe`.

However, the errors are not printed.

https://ci.ksp-ckan.space/job/CKAN-meta/1125/console

```
Validating metadata: 'AircraftCarrierAccessories/AircraftCarrierAccessories-1-1.2.1.ckan'
Build step 'Execute shell' marked build as failure
Discard old builds...
#1091 is removed because it is older than daysToKeep
#1090 is removed because it is older than daysToKeep
#1089 is removed because it is older than daysToKeep
#1088 is removed because it is older than daysToKeep
#1087 is removed because it is older than daysToKeep
Stopping all containers
```

Apparently the return value of a `$()` command still causes a script to terminate, so we don't have a chance to print the error message after it fails.

Now we no longer intercept the output of this command. This will allow us to see the errors when validation fails. Since it will print a nicely formatted version of the input file on success, the `cat "$ckan"` line is removed as redundant.