### PR TITLE
Reduce registry loading

### DIFF
--- a/NetKAN/build.sh
+++ b/NetKAN/build.sh
@@ -432,20 +432,25 @@ do
     # Create a dummy KSP install.
     create_dummy_ksp "$KSP_NAME" "${KSP_VERSIONS[@]}"
 
-    echo "Running ckan update"
-    mono ckan.exe update
+    # Get or restore fresh registry
+    if [[ ! -e registry.json ]]
+    then
+        echo "Running ckan update"
+        mono ckan.exe update
+        echo "Saving fresh registry file"
+        cp --verbose dummy_ksp/CKAN/registry.json .
+    else
+        echo "Restoring saved registry file"
+        cp --verbose registry.json dummy_ksp/CKAN
+    fi
 
     echo "Running ckan install -c $ckan"
-    mono ckan.exe install -c "$ckan" --headless
-
-    # Print list of installed mods.
-    mono ckan.exe list --porcelain
-
-    # Check the installed files for this .ckan file.
-    mono ckan.exe show "$CURRENT_IDENTIFIER"
-
-    # Cleanup.
-    mono ckan.exe ksp forget "$KSP_NAME"
+    mono ckan.exe prompt --headless <<EOCKAN
+install -c $ckan --headless
+list --porcelain
+show $CURRENT_IDENTIFIER
+ksp forget $KSP_NAME
+EOCKAN
 
     # Check for Installations that have gone wrong.
     gamedata=($(find dummy_ksp/GameData/. -name GameData -exec sh -c 'if test -d "{}"; then echo "{}";fi' \;))


### PR DESCRIPTION
## Problem

The validation scripts struggle to cope with large pull requests (>20 mods). They quickly deplete their allotted credits and then slow to a crawl until completion.

## Causes

Before we try tinkering with the server configuration, I found two places where we're doing unnecessary work:

1. We run `ckan update` for every module. This has the effect of importing our constructed `master.tar.gz` file into a fresh `registry.json` module and involves a lot of decompression, parsing, etc. Then we do it all over again for the next file, to generate an identical `registry.json` file.
2. The `registry.json` file is 18 MB, and loading it can take a few seconds. CmdLine does this every time you run an instance-specific command, for example `install`, `list`, and `show`. The scripts run multiple such commands, so they spend a lot of time and CPU parsing `registry.json`.

## Changes

1. Now after we run `ckan update`, we save a copy of the generated `registry.json` file and re-use it for all future inflations in the same run.
2. Now we run the CmdLine commands inside a `ckan.exe prompt` instance (see KSP-CKAN/CKAN#2273); this will parse the registry once at the beginning and then share it for successive commands.

This should reduce the disk and CPU consumption of the scripts, hopefully stretching their resources a bit further for big PRs.