### PR TITLE
Fail validation of .netkan files in CKAN-meta

### DIFF
--- a/CKAN-meta/build.sh
+++ b/CKAN-meta/build.sh
@@ -14,6 +14,7 @@ JQ_PATH="jq"
 EXIT_OK=0
 EXIT_NETKAN_VALIDATION_FAILED=2
 EXIT_FAILED_NO_GAME_VERSION=5
+EXIT_FAILED_NETKAN_IN_CKANMETA=6
 
 # Allow us to specify a commit id as the first argument
 if [ -n "$1" ]
@@ -323,6 +324,11 @@ fi
 
 for ckan in $COMMIT_CHANGES
 do
+    if [[ $ckan =~ \.netkan$ ]]
+    then
+        echo ".netkan file $ckan found, this repo is for .ckan files"
+        exit "$EXIT_FAILED_NETKAN_IN_CKANMETA"
+    fi
     # set -e doesn't apply inside an if block CKAN#1273
     if ! [[ $ckan =~ \.ckan$ ]]
     then


### PR DESCRIPTION
## Problem

KSP-CKAN/CKAN-meta#2110 almost committed a .netkan file to CKAN-meta, and the validation script let it slide.

![image](https://user-images.githubusercontent.com/1559108/87355614-48db9280-c526-11ea-96b9-b4b196e40e4b.png)

I guess this wouldn't have been too disruptive, but it's definitely not what CKAN-meta is for or what the author intends.

## Cause

The script just skips anything that doesn't end in `.ckan`, so it did nothing and reported no errors.

## Changes

Now a PR with a .netkan file in CKAN-meta will encounter a fatal error.