### PR TITLE
Don't tell the bot to trust the bot

### DIFF
--- a/ckan_meta_tester/__init__.py
+++ b/ckan_meta_tester/__init__.py
@@ -10,7 +10,7 @@ def test_metadata() -> None:
     logging.getLogger('').setLevel(
         environ.get('INPUT_LOG_LEVEL', 'info').upper())
 
-    ex = CkanMetaTester()
+    ex = CkanMetaTester(environ.get('GITHUB_ACTOR') == 'netkan-bot')
     exit(ExitStatus.success
          if ex.test_metadata(environ.get('INPUT_SOURCE',            'netkans'),
                              environ.get('INPUT_PULL_REQUEST_BODY', ''),

--- a/ckan_meta_tester/ckan_meta_tester.py
+++ b/ckan_meta_tester/ckan_meta_tester.py
@@ -38,9 +38,10 @@ class CkanMetaTester:
         'GITHUB_EVENT_BEFORE'
     ]
 
-    def __init__(self) -> None:
+    def __init__(self, i_am_the_bot: bool) -> None:
         self.source_to_ckan: Dict[Path, Path] = {}
         self.failed = False
+        self.i_am_the_bot = i_am_the_bot
 
     def test_metadata(self, source: str = 'netkans', pr_body: str = '', github_token: Optional[str] = None) -> bool:
 
@@ -221,7 +222,8 @@ class CkanMetaTester:
                 print(f'::error file={file}::{file.stem} is frozen, unfreeze it by renaming or deleting {frozen}', flush=True)
                 return False
         elif file.suffix == '.ckan':
-            print(f'::warning file={file}::Usually we should trust the bot to create .ckan files, are you sure you know what you\'re doing?')
+            if not self.i_am_the_bot:
+                print(f'::warning file={file}::Usually we should trust the bot to create .ckan files, are you sure you know what you\'re doing?')
             if len(file.parts) != 2:
                 print(f'::error file={file}::{file} should be placed in the folder named after its mod\'s identifier')
                 return False

--- a/tests/ckan_meta_tester.py
+++ b/tests/ckan_meta_tester.py
@@ -6,5 +6,5 @@ from ckan_meta_tester.ckan_meta_tester import CkanMetaTester
 class TestCkanMetaTester(unittest.TestCase):
 
     def test_true(self) -> None:
-        tester = CkanMetaTester()
+        tester = CkanMetaTester(False)
         self.assertTrue(tester.test_metadata())


### PR DESCRIPTION
## Problem

Every commit in CKAN-meta now has this warning applied to it, even for commits pushed by the bot:

- https://github.com/KSP-CKAN/CKAN-meta/actions

![image](https://user-images.githubusercontent.com/1559108/102669195-88e91600-4153-11eb-84bd-9bc33364454f.png)

## Changes

Now we skip that warning if `$GITHUB_ACTOR` is `netkan-bot`.