### PR TITLE
Print diffs after inflation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,13 @@ inputs:
             If it contains #overwrite_cache, cached files will be re-downloaded.
         required: false
 
+    diff meta root:
+        description: >
+            Path to location of local clone of CKAN-meta repo. If passed, each inflated .ckan
+            file will be diffed against the .ckan file with matching identifier and version
+            in the repo. Intended for NetKAN repo and mod meta-netkans.
+        required: false
+
 runs:
     using: docker
     image: Dockerfile

--- a/ckan_meta_tester/__init__.py
+++ b/ckan_meta_tester/__init__.py
@@ -14,5 +14,6 @@ def test_metadata() -> None:
     exit(ExitStatus.success
          if ex.test_metadata(environ.get('INPUT_SOURCE',            'netkans'),
                              environ.get('INPUT_PULL_REQUEST_BODY', ''),
-                             environ.get('GITHUB_TOKEN'))
+                             environ.get('GITHUB_TOKEN'),
+                             environ.get('INPUT_DIFF_META_ROOT'))
          else ExitStatus.failure)


### PR DESCRIPTION
## Background

This is #43 for the new GitHub Action framework from #61.

## Changes

Now a new `diff meta root` input allows a workflow to specify a location previously populated by `actions/checkout` with a clone of CKAN-meta (a shallow clone is fine). If passed, we use it to initialize a `CkanMetaRepo` object, which a new function `CkanInstall.find_diff` uses to find the previous/current version of itself and generate a diff in a collapsible section.

https://github.com/HebaruSan/NetKAN/runs/1610197642?check_suite_focus=true

![image](https://user-images.githubusercontent.com/1559108/103144942-76448300-46f7-11eb-9d5d-c63fd58e8a40.png)
