### PR TITLE
Use the better jsonlint

### DIFF
--- a/ckan_meta_tester/ckan_meta_tester.py
+++ b/ckan_meta_tester/ckan_meta_tester.py
@@ -84,7 +84,7 @@ class CkanMetaTester:
     def test_file(self, file: Path, overwrite_cache: bool, github_token: Optional[str] = None) -> bool:
         logging.debug('Attempting jsonlint for %s', file)
         if not self.run_for_file(
-            file, ['jsonlint-php', file], full_output_as_error=True):
+            file, ['jsonlint', '-s', '-v', file], full_output_as_error=True):
             logging.debug('jsonlint failed for %s', file)
             return False
         suffix = file.suffix.lower()
@@ -260,15 +260,17 @@ class CkanMetaTester:
             if full_output_as_error:
                 # This is the crazy method for putting newlines into ::error
                 full_output += line.replace('\n', '%0A')
-            if ' ERROR ' in line or ' FATAL ' in line:
+            elif ' ERROR ' in line or ' FATAL ' in line:
                 print(f'::error file={file}::{line}', flush=True, end='')
             elif ' WARN ' in line:
                 print(f'::warning file={file}::{line}', flush=True, end='')
             else:
                 print(line, flush=True, end='')
         if p.wait() == ExitStatus.success:
+            if full_output_as_error:
+                print(full_output, flush=True)
             return True
         else:
             if full_output_as_error:
-                print(f'::error file={file}::{full_output}', flush=True, end='')
+                print(f'::error file={file}::{full_output}', flush=True)
             return False

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'gitpython',
         'exitstatus',
         'requests',
+        'demjson',
     ],
     extras_require={
         'development': [


### PR DESCRIPTION
## Background

Previously, `xKAN-meta_testing` was some bash scripts that used a Python module to lint JSON.
After #61, it is some Python scripts that use a PHP module to lint JSON.

## Problems

The PHP linter is not as good as the Python one. It doesn't catch duplicate keys, for example, which have been known to appear in NetKAN pull requests. Plus it's weird to switch from Python to PHP when there's a suitable Python tool.

## Cause

When I was trying to replicate the functionality of the old Jenkins scripts, I did not know precisely what tools were being used. I looked for a `jsonlint` utility and found one, but it was the wrong one.

## Changes

Now we install [`demjson`](https://github.com/dmeranda/demjson), which is the Python module that provides `jsonlint`, and we run it instead of `jsonlint-php`. The old Jenkins scripts (on Ubuntu 14.04?) [made a symlink](https://github.com/KSP-CKAN/xKAN-meta_testing/blob/8cd65e555c50770b63e8bce3d71912aa038ac702/ckan-ci/Dockerfile#L8) from `/usr/bin/jsonlint-py` to `/usr/bin/jsonlint`, but this does not seem to be necessary anymore as the default name is now `jsonlint`.

`demjson` does not provide a great Python-to-Python interface to its linter; the [`demjson.jsonlint`](https://github.com/dmeranda/demjson/blob/5bc65974e7141746acc88c581f5d2dfb8ea14064/demjson.py#L5781-L6279) class contains all the linting logic, and its only useful public function is `main`, which essentially assumes it's running standalone (input is command line arguments, errors are printed to stdout, return value is Unix-style ints). So we won't instantiate it in-process but rather just call it as an external tool as we have been doing previously, since we already have scaffolding to make this work. The `-s` option makes the linting strict, and the `-v` option makes the output verbose.

After this is merged, we can stop installing `jsonlint-php` in this container, which might cut down its size if it was previously installing PHP and no longer needs to.