### PR TITLE
Game instance command is renamed

### DIFF
--- a/ckan_meta_tester/dummy_game_instance.py
+++ b/ckan_meta_tester/dummy_game_instance.py
@@ -30,7 +30,7 @@ class DummyGameInstance:
         self.where.mkdir()
         logging.debug('Populating fake instance contents')
         run(['mono', self.ckan_exe,
-             'ksp', 'fake',
+             'instance', 'fake',
              '--set-default', '--headless',
              'dummy', self.where, str(self.main_ver),
              *self._available_dlcs(self.main_ver)], capture_output=self.capture)
@@ -61,7 +61,7 @@ class DummyGameInstance:
     def __exit__(self, exc_type: Type[BaseException],
                  exc_value: BaseException, traceback: TracebackType) -> None:
         logging.debug('Removing instance from CKAN instance list')
-        run(['mono', self.ckan_exe, 'ksp', 'forget', 'dummy'], capture_output=self.capture)
+        run(['mono', self.ckan_exe, 'instance', 'forget', 'dummy'], capture_output=self.capture)
         logging.debug('Deleting instance contents')
         rmtree(self.where)
         logging.info('Dummy game instance deleted')

--- a/tests/dummy_game_instance.py
+++ b/tests/dummy_game_instance.py
@@ -51,7 +51,7 @@ class TestDummyGameInstance(TestCase):
             call(PosixPath('/game-instance'))
         ])
         self.assertEqual(mocked_run.mock_calls, [
-            call(['mono', PosixPath('/ckan.exe'), 'ksp', 'fake',
+            call(['mono', PosixPath('/ckan.exe'), 'instance', 'fake',
                   '--set-default', '--headless', 'dummy',
                   PosixPath('/game-instance'), '1.8.1',
                   '--MakingHistory', '1.1.0', '--BreakingGround', '1.0.0'],
@@ -63,6 +63,6 @@ class TestDummyGameInstance(TestCase):
                  capture_output=True),
             call(['mono', PosixPath('/ckan.exe'), 'update'],
                  capture_output=True),
-            call(['mono', PosixPath('/ckan.exe'), 'ksp', 'forget', 'dummy'],
+            call(['mono', PosixPath('/ckan.exe'), 'instance', 'forget', 'dummy'],
                  capture_output=True)
         ])


### PR DESCRIPTION
## Problem

KSP-CKAN/CKAN-meta#2228 and KSP-CKAN/NetKAN#8307 are failing with:

![image](https://user-images.githubusercontent.com/1559108/104345954-7fd63500-54c4-11eb-8ef0-3b00c6737238.png)

## Cause

KSP-CKAN/CKAN#3223 renamed the `ckan ksp *` commands to `ckan instance *` to make it generic enough for any game. The test scripts still use the old command, so they're failing to create the fake instance for testing, and the parent directory of the downloads symlink doesn't exist.

## Changes

Now the script is updated to use the new command name.