### PR TITLE
Remove GITHUB_ prefix from our env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ jobs:
               uses: KSP-CKAN/xKAN-meta_testing@master
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  GITHUB_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-                  GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+                  PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  EVENT_BEFORE: ${{ github.event.before }}
               with:
                   source: commits
                   pull request body: ${{ github.event.pull_request.body }}
@@ -108,8 +108,8 @@ jobs:
               uses: KSP-CKAN/xKAN-meta_testing@master
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  GITHUB_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-                  GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+                  PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  EVENT_BEFORE: ${{ github.event.before }}
               with:
                   source: commits
                   pull request body: ${{ github.event.pull_request.body }}

--- a/ckan_meta_tester/ckan_meta_tester.py
+++ b/ckan_meta_tester/ckan_meta_tester.py
@@ -40,8 +40,8 @@ class CkanMetaTester:
     GNU_LINE_COL_PATTERN = re.compile(r'^[^:]+:(?P<line>[0-9]+)[:.](?P<col>[0-9]+)')
 
     REF_ENV_VARS = [
-        'GITHUB_PR_BASE_SHA',
-        'GITHUB_EVENT_BEFORE'
+        'PR_BASE_SHA',
+        'EVENT_BEFORE'
     ]
 
     def __init__(self, i_am_the_bot: bool) -> None:


### PR DESCRIPTION
## Problem

Pull request validation is pulling in changes that were committed to master after the PR's branch was forked.

https://github.com/KSP-CKAN/NetKAN/pull/8430/checks?check_run_id=2160596226

Notably, these values are correct, which should give us a correct diff:

```
  env:
    GITHUB_TOKEN: ***
    GITHUB_PR_BASE_SHA: 20972a574c269908ecdb8dfbff4f347021f3fb7a
    GITHUB_EVENT_BEFORE: 4c0419e413b621c0156cb178996476f0e2e8851b
```

## Cause

I think GitHub is blocking us from passing those values to the code:

https://docs.github.com/en/actions/reference/environment-variables#naming-conventions-for-environment-variables

> Note: GitHub reserves the GITHUB_ environment variable prefix for internal use by GitHub. Setting an environment variable or secret with the GITHUB_ prefix will result in an error.

## Changes

Now our Action looks for `PR_BASE_SHA` and `EVENT_BEFORE` instead. I think we can set these.

Note that we we will have to update the workflow yaml files to match before this will be fixed.