### PR TITLE
Logging for branch_diff

### DIFF
--- a/ckan_meta_tester/ckan_meta_tester.py
+++ b/ckan_meta_tester/ckan_meta_tester.py
@@ -193,7 +193,11 @@ class CkanMetaTester:
                 if f.is_file() and f.suffix.lower() == '.netkan')
 
     def branch_diff(self, repo: Repo) -> DiffIndex:
-        return repo.commit(self.get_start_ref()).diff(repo.head.commit)
+        start_ref = self.get_start_ref()
+        logging.info('Looking for changes between %s and %s', start_ref, repo.head.commit.hexsha)
+        start_commit = repo.commit(start_ref)
+        logging.info('Start commit sha is %s', start_commit.hexsha)
+        return start_commit.diff(repo.head.commit)
 
     def get_start_ref(self, default: str = 'origin/master') -> str:
         ref = None


### PR DESCRIPTION
## Motivation

#73 continues to happen and is very confusing. `get_start_ref()` must be misbehaving somehow, but it can't be.

When a but seems impossible, the answer is more logging messages.

## Changes

- Now we print what `get_start_ref()` returns; if `get_start_ref()` is doing something weird, this message will tell us that
- When we look up the starting commit, we print that commit's `hexsha`; this will tell us if we can't use `get_start_ref()`'s return value correctly somehow

After this we should be able to rule out some causes of this bug. We might be able to fix it, or we might add even more logging messages.

I'm planning to do "self review" of these changes. I would have just pushed them, but I want to make sure the tests and mypy still work.
