### PR TITLE
Allow YAML format for .netkans

### DIFF
--- a/ckan_meta_tester/ckan_meta_tester.py
+++ b/ckan_meta_tester/ckan_meta_tester.py
@@ -90,14 +90,19 @@ class CkanMetaTester:
 
     def test_file(self, file: Path, overwrite_cache: bool, github_token: Optional[str] = None, meta_repo: Optional[CkanMetaRepo] = None) -> bool:
         logging.debug('Attempting jsonlint for %s', file)
-        if not self.run_for_file(
-            file, ['jsonlint', '-s', '-v', file], full_output_as_error=True, gnu_line_col_fmt=True):
-            logging.debug('jsonlint failed for %s', file)
-            return False
         suffix = file.suffix.lower()
         if suffix == '.netkan':
+            if not self.run_for_file(
+                file, ['yamllint', '-d', '{extends: relaxed, rules: {colons: disable}}', file],
+                full_output_as_error=True, gnu_line_col_fmt=True):
+                logging.debug('yamllint failed for %s', file)
+                return False
             return self.inflate_file(file, overwrite_cache, github_token, meta_repo)
         elif suffix == '.ckan':
+            if not self.run_for_file(
+                file, ['jsonlint', '-s', '-v', file], full_output_as_error=True, gnu_line_col_fmt=True):
+                logging.debug('jsonlint failed for %s', file)
+                return False
             return self.validate_file(file, overwrite_cache, github_token)
         else:
             raise ValueError(f'Cannot test file {file}, must be .netkan or .ckan')

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'exitstatus',
         'requests',
         'demjson',
+        'yamllint',
     ],
     extras_require={
         'development': [


### PR DESCRIPTION
## Motivation

See KSP-CKAN/CKAN#3367, we might want to allow .netkans to use YAML format. If so, our pull request validation Action will need to be able to handle that.

## Changes

Now if a file is a .netkan, we use `yamllint` instead of `jsonlint` to validate its syntax.

Parsing of these files for our own use is taken care of in KSP-CKAN/NetKAN-Infra#219.

This should allow a pull request to be submitted to the NetKAN repo using YAML format with correct validation.