### PR TITLE
Get PR body during workflow runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
             - name: Test meta-netkans
               uses: KSP-CKAN/xKAN-meta_testing@master
               with:
-                  pull request body: ${{ github.event.pull_request.body }}
+                  pull request url: ${{ github.event.pull_request.url }}
 ```
 
 If you're on the CKAN dev team, a few changes are needed for the main metadata repos, to make the Action search the commit history for changes:
@@ -75,7 +75,7 @@ jobs:
                   EVENT_BEFORE: ${{ github.event.before }}
               with:
                   source: commits
-                  pull request body: ${{ github.event.pull_request.body }}
+                  pull request url: ${{ github.event.pull_request.url }}
 ```
 
 CKAN-meta should use essentially the same configuration with different labels; the script handles both .netkan and .ckan files depending on what is in the repo:
@@ -114,7 +114,7 @@ jobs:
                   EVENT_BEFORE: ${{ github.event.before }}
               with:
                   source: commits
-                  pull request body: ${{ github.event.pull_request.body }}
+                  pull request url: ${{ github.event.pull_request.url }}
 ```
 
 ## See also

--- a/action.yml
+++ b/action.yml
@@ -24,12 +24,12 @@ inputs:
         required: false
         default: netkans
 
-    pull request body:
+    pull request url:
         description: >-
-            The body of the pull request associated with these changes.
-            Used to extract game version compatibility overrides a la:
+            The API URL of the pull request associated with these changes.
+            Used to extract game version compatibility overrides from the body a la:
             `ckan compat add 1.8 1.9`
-            If it contains #overwrite_cache, cached files will be re-downloaded.
+            If the body contains #overwrite_cache, cached files will be re-downloaded.
         required: false
 
     diff meta root:

--- a/ckan_meta_tester/__init__.py
+++ b/ckan_meta_tester/__init__.py
@@ -1,6 +1,10 @@
+import json
 import logging
+import requests
 from os import environ
 from exitstatus import ExitStatus
+from typing import Optional
+from urllib.parse import urlparse
 
 from .ckan_meta_tester import CkanMetaTester
 
@@ -10,10 +14,32 @@ def test_metadata() -> None:
     logging.getLogger('').setLevel(
         environ.get('INPUT_LOG_LEVEL', 'info').upper())
 
+    github_token = environ.get('GITHUB_TOKEN')
+
     ex = CkanMetaTester(environ.get('GITHUB_ACTOR') == 'netkan-bot')
     exit(ExitStatus.success
-         if ex.test_metadata(environ.get('INPUT_SOURCE',            'netkans'),
-                             environ.get('INPUT_PULL_REQUEST_BODY', ''),
-                             environ.get('GITHUB_TOKEN'),
+         if ex.test_metadata(environ.get('INPUT_SOURCE', 'netkans'),
+                             get_pr_body(github_token, environ.get('INPUT_PULL_REQUEST_URL')),
+                             github_token,
                              environ.get('INPUT_DIFF_META_ROOT'))
          else ExitStatus.failure)
+
+
+def get_pr_body(github_token: Optional[str], pr_url: Optional[str]) -> str:
+    # Get PR body text
+    if pr_url:
+        headers = { 'Accept': 'application/vnd.github.v3.raw+json' }
+        parsed_pr_url = urlparse(pr_url)
+        if github_token:
+            if parsed_pr_url.scheme == 'https' and parsed_pr_url.netloc == 'api.github.com' \
+                    and parsed_pr_url.path.startswith('/repos/'):
+                headers['Authorization'] = f'token {github_token}'
+            else:
+                logging.warning('Invalid pull request url, omitting Authorization header')
+
+        resp = requests.get(pr_url, headers=headers)
+        if resp.ok:
+            return resp.json().get('body', '')
+        else:
+            logging.warning(resp.text)
+    return ''


### PR DESCRIPTION
## Problem
Overwriting compatibility through the `ckan compat add` command in the PR body does currently only work after a new commit is pushed, because GitHub otherwise doesn't update the workflow context, and a re-run still receives the old PR body.

## Changes
Now instead of passing the PR body as action input, which doesn't get updated when re-running, we only pass the PR API URL, which is static, and `ckan_meta_tester/__init__.py` does a request to the API and gets the up to date PR body.

The `pull request body` input has been renamed to `pull request url`, and takes `${{ github.event.pull_request.url }}` ([docs](https://docs.github.com/en/rest/reference/pulls#list-pull-requests--code-samples)).
Since we're still the only one using this image [as far as I can see](https://github.com/search?q=KSP-CKAN+%2F+xKAN-meta_testing&type=code), this "breaking change" is no problem.
I'll do PRs to update CKAN-eta's and NetKAN's workflow files accordingly.

I've tested this [here](https://github.com/DasSkelett/NetKAN/pull/3) by building and pushing a [custom Docker image](https://hub.docker.com/r/dasskelett/metadata), and changing the `image` of `action.yml` and `uses` of NetKAN's `inflate.yml`.