### PR TITLE
Output YAML linting errors in GitHub format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+.pytest_cache/
+.cache/

--- a/ckan_meta_tester/ckan_meta_tester.py
+++ b/ckan_meta_tester/ckan_meta_tester.py
@@ -93,8 +93,7 @@ class CkanMetaTester:
         suffix = file.suffix.lower()
         if suffix == '.netkan':
             if not self.run_for_file(
-                file, ['yamllint', '-d', '{extends: relaxed, rules: {colons: disable}}', file],
-                full_output_as_error=True, gnu_line_col_fmt=True):
+                file, ['yamllint', '-f', 'github', '-d', '{extends: relaxed, rules: {colons: disable}}', file]):
                 logging.debug('yamllint failed for %s', file)
                 return False
             return self.inflate_file(file, overwrite_cache, github_token, meta_repo)

--- a/ckan_meta_tester/game_version.py
+++ b/ckan_meta_tester/game_version.py
@@ -70,4 +70,4 @@ class GameVersion:
         return self.val
 
     def __repr__(self) -> str:
-        return f'<GameVersion {self.val}>'
+        return f'<GameVersion({self.val})>'


### PR DESCRIPTION
## Problem

The output of `yamllint` is a bit strange:

![image](https://user-images.githubusercontent.com/1559108/127207990-2a158e79-d69b-451e-9d48-9e90e6f4f445.png)

The `::error` prefix stuff should be consumed by GitHub and not shown to the user, so that's weird. Then it's strange that the other warnings also show up, and not with the same problem.

## Cause

The parameters to `run_for_file` currently mean we're treating the entire output as one error and then trying to deduce the line and column based on GNU error syntax and reformat it into GitHub workflow output syntax, since this was needed for the old `jsonlint` tool. This probably mangles the output somewhat.

- https://www.gnu.org/prep/standards/html_node/Errors.html
- https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions

## Amazing discovery

`yamllint` natively supports our target output format!

https://yamllint.readthedocs.io/en/stable/integration.html#integration-with-github-actions

> yamllint auto-detects when it’s running inside of [GitHub Actions](https://github.com/features/actions) and automatically uses the suited output format to decorate code with linting errors automatically. You can also force the GitHub Actions output with yamllint --format github.

## So, the real cause

The output is already in GitHub format, and we're taking that output, parsing the line and column, and then re-outputting it with additional GitHub syntax formatting!

## Changes

- Now we force `github` format (should have no effect, but good to be explicit so maintainers know this is a thing)
- Now we don't do any special parsing of the output, so the errors and warnings will flow through unimpeded
- `GameVersion.__repr__` is now formatted as in KSP-CKAN/NetKAN-Infra#225

I'll probably do self-review on this so we can see it in action the next time there's a pull request.