### PR TITLE
Calculate diff from merge base to PR HEAD

### DIFF
--- a/ckan_meta_tester/__init__.py
+++ b/ckan_meta_tester/__init__.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import requests
 from os import environ
@@ -39,7 +38,12 @@ def get_pr_body(github_token: Optional[str], pr_url: Optional[str]) -> str:
 
         resp = requests.get(pr_url, headers=headers)
         if resp.ok:
-            return resp.json().get('body', '')
+            body = resp.json().get('body')
+            if not body:
+                # If the PR has an empty body, 'body' is set to None, not the empty string
+                logging.warning('::warning::Pull requests should have a description with a summary of the changes')
+                return ''
+            return body
         else:
             logging.warning(resp.text)
     return ''

--- a/ckan_meta_tester/__init__.py
+++ b/ckan_meta_tester/__init__.py
@@ -41,7 +41,7 @@ def get_pr_body(github_token: Optional[str], pr_url: Optional[str]) -> str:
             body = resp.json().get('body')
             if not body:
                 # If the PR has an empty body, 'body' is set to None, not the empty string
-                logging.warning('::warning::Pull requests should have a description with a summary of the changes')
+                print('::warning::Pull requests should have a description with a summary of the changes')
                 return ''
             return body
         else:


### PR DESCRIPTION
Another attempt to fix #73, as apparently it still isn't working as intended.

## Problem
My theory of what the issue is right now: we are essentially diffing the master at the time of the commit to the HEAD of the PR branch. This basically adds the inverses of all those commits to the diff, that are only in master but not in the PR branch.
You can imagine Git starting from master, going backwards until it reaches the last common commit (merge base), then going forwards until it reaches the PR HEAD.
```
   → D → E   <-- PR HEAD
A
   ← B ← C   <-- master

Diff: -C + -B + D + E
```

This will trigger netkans to be inflated that had inflation errors and have been fixed in master (but not the PR branch because it doesn't include those commits).

---

And one unrelated bug, from https://github.com/KSP-CKAN/NetKAN/pull/8694 caused by #76:
```
Traceback (most recent call last):
  File "/usr/local/bin/ckanmetatester", line 11, in <module>
    load_entry_point('CkanMetaTester==0.1', 'console_scripts', 'ckanmetatester')()
  File "/usr/local/lib/python3.7/dist-packages/ckan_meta_tester/__init__.py", line 24, in test_metadata
    environ.get('INPUT_DIFF_META_ROOT'))
  File "/usr/local/lib/python3.7/dist-packages/ckan_meta_tester/ckan_meta_tester.py", line 59, in test_metadata
    overwrite_cache = ('#overwrite_cache' in pr_body)
TypeError: argument of type 'NoneType' is not iterable
```

## Solution
Instead of starting the diff from the master HEAD, let's start it from that merge base, the last common commit. This generates a diff from commits only on the PR branch, and thus a list that only includes files that have been changed in this PR.
```
   → D → E   <-- PR HEAD
A
     B   C   <-- master (we don't care)

Diff: D + E
```

As @HebaruSan noted in [this comment](https://github.com/KSP-CKAN/xKAN-meta_testing/issues/73#issuecomment-887612303), this does not necessarily reflect the true changes of the PR as they would be after merge, as a merge _combines_ all commits, which could make differences if a file got modified on master _and_ the PR branch.

However, we only care about the list of changed files, not the actual diff content. So for us, this would only change the outcome if the PR somehow reverts a commit on master without containing that commit (or even just its changes but in a different commit) from master, making the file "unmodified" in the total merge diff.
I don't think this is even possible though, as you can't revert changes that you didn't do yet. Maybe somehow with merge conflicts, but those would need to be resolved beforehand anyway.

But in case we _want_ to diff to the merge commit to be on the safe side (assuming it would behave as we understand right now), this would need to be changed in the workflow files, by removing the `ref` again.

## Changes
GitPython fortunately gives us a handy function that calculates the merge base (basically `git merge-base`).
We diff from that merge base commit to the HEAD of the PR branch.

---

If the PR body is `None`/`null` in the JSON returned from the API, it falls back to an empty string, but also logs a warning that nudges the author towards providing a PR description in the future, as every PR should have one.
Decided against failing the inflation, as I think this would really annoy a theoretical person maintaining many mods and doing lots of PRs with a tendency not to give sufficient information about the purposes of their pull requests.

Fixes #73 (maybe)