### PR TITLE
Move INFLATED_PATH into working directory

### DIFF
--- a/ckan_meta_tester/ckan_meta_tester.py
+++ b/ckan_meta_tester/ckan_meta_tester.py
@@ -27,7 +27,7 @@ class CkanMetaTester:
     NETKAN_PATH = BIN_PATH.joinpath('netkan.exe')
     CKAN_PATH   = BIN_PATH.joinpath('ckan.exe')
 
-    INFLATED_PATH = Path('/ckans')
+    INFLATED_PATH = Path('.ckans')
     CACHE_PATH    = Path('.cache')
     REPO_PATH     = Path('.repo').resolve()
     TINY_REPO     = REPO_PATH.joinpath('metadata.tar.gz')
@@ -48,6 +48,7 @@ class CkanMetaTester:
         self.source_to_ckans: OrderedDict[Path, List[Path]] = OrderedDict()
         self.failed = False
         self.i_am_the_bot = i_am_the_bot
+        makedirs(self.INFLATED_PATH, exist_ok=True)
         makedirs(self.REPO_PATH, exist_ok=True)
 
     def test_metadata(self, source: str = 'netkans', pr_body: str = '', github_token: Optional[str] = None, diff_meta_root: Optional[str] = None) -> bool:


### PR DESCRIPTION
Another one in the series to get https://github.com/KSP-CKAN/NetKAN/pull/8704 to work properly.
Per [my comment](https://github.com/KSP-CKAN/NetKAN/pull/8704#issuecomment-895115027) on that PR, instead of the `/repo` / `.repo` directory, let's do it with `/ckans` / `.ckans` instead, to avoid the double compression.

For that, we need to move `/ckans` to the working directory (`.ckans`) as well, so it is within the volume mounted into the container and thus still reachable after the action container exits.

Theoretically, we could move `.repo` back, but we might as well keep it where it is, maybe we _do_ need to access it for other things in the future.

Will also prepare PRs for necessary changes in the the NetKAN and CKAN repo.