### PR TITLE
Suppress debug output

### DIFF
--- a/ckan_meta_tester/ckan_meta_tester.py
+++ b/ckan_meta_tester/ckan_meta_tester.py
@@ -200,7 +200,7 @@ class CkanMetaTester:
 
     def branch_diff(self, repo: Repo) -> DiffIndex:
         start_ref = self.get_start_ref()
-        logging.info('Looking for merge base between %s and %s', start_ref, repo.head.commit.hexsha)
+        logging.debug('Looking for merge base between %s and %s', start_ref, repo.head.commit.hexsha)
         start_commit = repo.commit(start_ref)
         # Has one item or none
         common_ancestors = repo.merge_base(start_commit, repo.head.commit)
@@ -208,8 +208,8 @@ class CkanMetaTester:
             raise ValueError(f'Could not find common ancestor between start ref {start_commit.hexsha}'
                              f' and HEAD {repo.head.commit.hexsha}')
         merge_base = common_ancestors[0]
-        logging.info('Looking for changes between %s and %s', merge_base, repo.head.commit.hexsha)
-        logging.info('Base commit sha is %s', merge_base.hexsha)
+        logging.debug('Looking for changes between %s and %s', merge_base, repo.head.commit.hexsha)
+        logging.debug('Base commit sha is %s', merge_base.hexsha)
         return merge_base.diff(repo.head.commit)
 
     def get_start_ref(self, default: str = 'origin/master') -> str:


### PR DESCRIPTION
## Problem

All pull request checks start with this (with different hex values for each PR):

```
INFO:root:Looking for merge base between eca97cb2214e6f2f2a80ffde1646eca377cddef6 and bd2f06fe4e50237c282860934e8cce361aed73db
INFO:root:Looking for changes between eca97cb2214e6f2f2a80ffde1646eca377cddef6 and bd2f06fe4e50237c282860934e8cce361aed73db
INFO:root:Base commit sha is eca97cb2214e6f2f2a80ffde1646eca377cddef6
```

## Cause

We added this in #74 and #79 so we could investigate why #73 was still happening despite previous efforts to fix it. The hex values allowed us to find each relevant commit in the git log and determine which ones were being used and why.

## Changes

Now that #73 seems to be fixed (finally!), these calls are changed from `logging.info` to `logging.debug`, so they will only appear if we turn on debugging output in the Action's config.

I'm planning to self-review and merge this because it's just some minor clean-up.