### PR TITLE
Set bot useragent for GitHub Action

### DIFF
--- a/ckan_meta_tester/ckan_meta_tester.py
+++ b/ckan_meta_tester/ckan_meta_tester.py
@@ -26,6 +26,7 @@ class CkanMetaTester:
     BIN_PATH    = Path('/usr/local/bin')
     NETKAN_PATH = BIN_PATH.joinpath('netkan.exe')
     CKAN_PATH   = BIN_PATH.joinpath('ckan.exe')
+    USER_AGENT  = 'Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/xKAN-meta_testing)'
 
     INFLATED_PATH = Path('.ckans')
     CACHE_PATH    = Path('.cache')
@@ -151,6 +152,7 @@ class CkanMetaTester:
                 ['mono', self.NETKAN_PATH,
                  *(['--github-token', github_token] if github_token is not None else []),
                  '--cachedir', self.CACHE_PATH,
+                 '--net-useragent', self.USER_AGENT,
                  *(['--overwrite-cache'] if overwrite_cache else []),
                  '--validate-ckan', file]):
                 return False
@@ -179,7 +181,8 @@ class CkanMetaTester:
 
                 return self.run_for_file(
                     orig_file,
-                    ['mono', self.CKAN_PATH, 'prompt', '--headless'],
+                    ['mono', self.CKAN_PATH, 'prompt', '--headless',
+                     '--net-useragent', self.USER_AGENT],
                     input=self.CKAN_INSTALL_TEMPLATE.substitute(
                         ckanfile=file, identifier=ckan.identifier))
 


### PR DESCRIPTION
## Motivation

See KSP-CKAN/CKAN#3490; when the GitHub Action uses `netkan.exe` and `ckan.exe`, its `User-Agent` does not identify it as a bot, which it ought to do, see KSP-SpaceDock/SpaceDock#436.

## Changes

Based on the same examples used for that other pull request, the GitHub Action's `User-Agent` is now:

`Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/xKAN-meta_testing)`

I think parsers will just check whether `bot` occurs in the browser family.

### Blocking external dependencies

The `HyperEdit` and `Graphotron` mods use a combination of strange URLs:

- <http://www.kerbaltek.com/_IamCKAN_Gimme_hyperedit_#cachebuster1>
- <http://www.kerbaltek.com/_IamCKAN_Gimme_graphotron_>

... and the `User-Agent` string to identify Netkan requests. Requesting these URLs with the wrong `User-Agent` string results in an HTTP status 403 error. Before we merge these changes, we must work with @Ezriilc to update the `kerbaltek.com` site to support the new `User-Agent` formats as well as the old format.