### PR TITLE
Trigger CKAN repo deploy workflow on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy xKAN-meta_testing
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    name: CKAN repo dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: CKAN repo dispatch
+        env:
+          REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+        if: env.REPO_ACCESS_TOKEN
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          repository: KSP-CKAN/CKAN
+          event-type: deploy
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
## Motivation

When this repo changes, we have to trigger the CKAN repo's `deploy` workflow manually, which is inconvenient, easy to forget, and non-discoverable for new maintainers.

## Background

KSP-CKAN/CKAN#3575 is adding a repository dispatch `deploy` event that other repositories will be able to use to trigger that workflow programmatically. That pull request should be merged before this one, so the trigger will be available when we try to use it.

This Action can be used for the triggering:

https://github.com/peter-evans/repository-dispatch

## Changes

Now a new `deploy` workflow triggers the `deploy` repo dispatch event in the CKAN repo so the metadata validation image will be rebuilt.

Note that this required adding a `REPO_ACCESS_TOKEN` secret to this repo containing a [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with `public_repo` scope and `write` access to the CKAN repo. This was done.
