### PR TITLE
Test uninstallation of mods after install

### DIFF
--- a/ckan_meta_tester/ckan_install_identifiers_template.txt
+++ b/ckan_meta_tester/ckan_install_identifiers_template.txt
@@ -1,3 +1,4 @@
 cache setlimit 5000
 install $identifiers --headless
 list --porcelain
+remove $identifiers --headless

--- a/ckan_meta_tester/ckan_install_template.txt
+++ b/ckan_meta_tester/ckan_install_template.txt
@@ -1,3 +1,4 @@
 install -c $ckanfile --headless
 list --porcelain
 show --with-versions $identifier
+remove $identifier --headless


### PR DESCRIPTION
## Motivation

Sometimes a bug may prevent CKAN from uninstalling a mod that it is able to install (see KSP-CKAN/CKAN#3586). It would be nice to test uninstallation as well during a pull request to catch that.

## Changes

Now we uninstall the mods after we install them. This is done by adding a `remove` command to the `ckan prompt` input template files. This should make it easier to catch issues with uninstallation.

I'll self-review this.
