### PR TITLE
Warn on every file for empty PR body

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,3 +7,4 @@ ignore=
 
 disable=
     missing-docstring,
+    line-too-long


### PR DESCRIPTION
## Motivation

We have a warning for an empty pull request body, which has been firing reliably on all of @linuxgurugamer's pull requests. However, it only shows up in the "Checks" tab, while some users may find it more convenient to check only the "Files changed" tab, which shows just about everything else.

## Changes

- Now if you submit a PR with an empty description, every file in the PR will show the warning. Yes, this means we will repeat the output; if this is found to be annoying, the easy solution is to describe the purpose of the pull request in the description.
- Since Atom seems to be abandoned, I have switched to Vscodium, and it showed me that Pylint had many lower-priority suggestions about these files. Most of them are now addressed, excluding the "Too many arguments" and "Too many branches" hints for `run_for_file`, which would require larger changes.

I'll self-review this, merge, and watch for problems the next time we have a NetKAN pull request.
