### PR TITLE
KSP2 netkan validation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,12 @@ inputs:
         required: false
         default: info
 
+    game:
+        description: |-
+            Short name of the game to be used for inflation, either KSP or KSP2
+        required: false
+        default: KSP
+
     source:
         description: |-
             What to test:

--- a/ckan_meta_tester/__init__.py
+++ b/ckan_meta_tester/__init__.py
@@ -18,7 +18,8 @@ def test_metadata() -> None:
 
     github_token = environ.get('GITHUB_TOKEN')
 
-    ex = CkanMetaTester(environ.get('GITHUB_ACTOR') == 'netkan-bot')
+    ex = CkanMetaTester(environ.get('GITHUB_ACTOR') == 'netkan-bot',
+                        environ.get('INPUT_GAME', 'KSP'))
     sys.exit(ExitStatus.success
              if ex.test_metadata(environ.get('INPUT_SOURCE', 'netkans'),
                                  get_pr_body(github_token, environ.get('INPUT_PULL_REQUEST_URL')),

--- a/ckan_meta_tester/ckan_install.py
+++ b/ckan_meta_tester/ckan_install.py
@@ -1,32 +1,22 @@
-import re
-import requests
 import logging
-from collections import OrderedDict
 from difflib import unified_diff
 from typing import List, Optional
 
 from netkan.metadata import Ckan
 from netkan.repos import CkanMetaRepo
 
+from .game import Game
 from .game_version import GameVersion
 
-
-# Should be a class constant, but then we can't access it from KNOWN_VERSIONS's lambda
-BUILD_PATTERN=re.compile('\.[0-9]+$')
 
 class CkanInstall(Ckan):
     """Metadata file representation with extensions for installation"""
 
-    BUILDS_URL = 'https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/Core/builds.json'
-    KNOWN_VERSIONS = [GameVersion(v) for v in OrderedDict.fromkeys(map(
-        lambda v: BUILD_PATTERN.sub('', v),
-        requests.get(BUILDS_URL).json().get('builds').values()))]
-
-    def compat_versions(self) -> List[GameVersion]:
+    def compat_versions(self, game: Game) -> List[GameVersion]:
         minv = self.lowest_compat()
         maxv = self.highest_compat()
         logging.debug('Finding versions from %s to %s', minv, maxv)
-        return [v for v in self.KNOWN_VERSIONS
+        return [v for v in game.versions
                 if v.compatible(minv, maxv)]
 
     def lowest_compat(self) -> GameVersion:

--- a/ckan_meta_tester/dummy_game_instance.py
+++ b/ckan_meta_tester/dummy_game_instance.py
@@ -5,6 +5,7 @@ from subprocess import run
 from types import TracebackType
 from typing import Type, List
 
+from .game import Game
 from .game_version import GameVersion
 
 
@@ -14,7 +15,7 @@ class DummyGameInstance:
     MAKING_HISTORY_VERSION=GameVersion('1.4.1')
     BREAKING_GROUND_VERSION=GameVersion('1.7.1')
 
-    def __init__(self, where: Path, ckan_exe: Path, addl_repo: Path, main_ver: GameVersion, other_versions: List[GameVersion], cache_path: Path) -> None:
+    def __init__(self, where: Path, ckan_exe: Path, addl_repo: Path, main_ver: GameVersion, other_versions: List[GameVersion], cache_path: Path, game: Game) -> None:
         self.where = where
         self.registry_path = self.where.joinpath('CKAN').joinpath('registry.json')
         self.ckan_exe = ckan_exe
@@ -22,6 +23,7 @@ class DummyGameInstance:
         self.main_ver = main_ver
         self.other_versions = other_versions
         self.cache_path = cache_path
+        self.game = game
         # Hide ckan.exe output unless debugging is enabled
         self.capture = not logging.getLogger().isEnabledFor(logging.DEBUG)
 
@@ -31,6 +33,7 @@ class DummyGameInstance:
         logging.debug('Populating fake instance contents')
         run(['mono', self.ckan_exe,
              'instance', 'fake',
+             '--game', self.game.short_name,
              '--set-default', '--headless',
              'dummy', self.where, str(self.main_ver),
              *self._available_dlcs(self.main_ver)],

--- a/ckan_meta_tester/game.py
+++ b/ckan_meta_tester/game.py
@@ -1,0 +1,55 @@
+import re
+import requests
+from collections import OrderedDict
+from typing import List, Dict, Optional, cast
+
+from .game_version import GameVersion
+
+class Game:
+    BUILDS_URL = ''
+
+    def __init__(self) -> None:
+        self.versions = self._versions_from_json(
+            requests.get(self.BUILDS_URL).json())
+
+    @property
+    def short_name(self) -> str:
+        raise NotImplementedError
+
+    def _versions_from_json(self, json: object) -> List[GameVersion]:
+        raise NotImplementedError
+
+    @staticmethod
+    def from_id(game_id: str = 'KSP') -> 'Game':
+        if game_id == 'KSP':
+            return Ksp1()
+        if game_id == 'KSP2':
+            return Ksp2()
+        raise ValueError('game_id must be either KSP or KSP2')
+
+
+class Ksp1(Game):
+    BUILDS_URL = 'https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/builds.json'
+    BUILD_PATTERN=re.compile(r'\.[0-9]+$')
+
+    @property
+    def short_name(self) -> str:
+        return 'KSP'
+
+    def _versions_from_json(self, json: object) -> List[GameVersion]:
+
+        return [GameVersion(v) for v in OrderedDict.fromkeys(map(
+            lambda v: self.BUILD_PATTERN.sub('', v),
+            cast(Dict[str, Dict[str, str]], json).get('builds', {}).values()))]
+
+
+class Ksp2(Game):
+    BUILDS_URL = 'https://raw.githubusercontent.com/KSP-CKAN/KSP2-CKAN-meta/master/builds.json'
+
+    @property
+    def short_name(self) -> str:
+        return 'KSP2'
+
+    def _versions_from_json(self, json: object) -> List[GameVersion]:
+        # The KSP2 builds.json doesn't have build ids
+        return [GameVersion(v) for v in cast(List[str], json)]

--- a/tests/ckan_install.py
+++ b/tests/ckan_install.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from ckan_meta_tester.ckan_install import CkanInstall
 from ckan_meta_tester.game_version import GameVersion
-
+from ckan_meta_tester.game import Ksp1
 
 class TestCkanInstall(TestCase):
 
@@ -24,7 +24,7 @@ class TestCkanInstall(TestCase):
         # Act / Assert
         self.assertEqual(cki.lowest_compat(), GameVersion('1.8'))
         self.assertEqual(cki.highest_compat(), GameVersion('1.10'))
-        self.assertEqual(cki.compat_versions(), [
+        self.assertEqual(cki.compat_versions(Ksp1()), [
             GameVersion('1.8.0'), GameVersion('1.8.1'),
             GameVersion('1.9.0'), GameVersion('1.9.1'),
             GameVersion('1.10.0'), GameVersion('1.10.1'),

--- a/tests/ckan_meta_tester.py
+++ b/tests/ckan_meta_tester.py
@@ -6,11 +6,11 @@ from ckan_meta_tester.ckan_meta_tester import CkanMetaTester
 class TestCkanMetaTester(unittest.TestCase):
 
     def test_true(self) -> None:
-        tester = CkanMetaTester(False)
+        tester = CkanMetaTester(False, 'KSP')
         self.assertTrue(tester.test_metadata())
 
     def test_pr_body_tests(self) -> None:
-        tester = CkanMetaTester(False)
+        tester = CkanMetaTester(False, 'KSP')
         result = tester.pr_body_tests("""
         ## Description
         Basic test case

--- a/tests/dummy_game_instance.py
+++ b/tests/dummy_game_instance.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from unittest.mock import Mock, patch, call
 from tempfile import TemporaryDirectory, TemporaryFile
 
+from ckan_meta_tester.game import Game
 from ckan_meta_tester.game_version import GameVersion
 from ckan_meta_tester.dummy_game_instance import DummyGameInstance
 
@@ -34,7 +35,8 @@ class TestDummyGameInstance(TestCase):
             Path('/repo/metadata.tar.gz'),
             GameVersion('1.8.1'),
             [GameVersion('1.8.0')],
-            Path('/cache')):
+            Path('/cache'),
+            Game.from_id('KSP')):
 
             pass
 
@@ -52,6 +54,7 @@ class TestDummyGameInstance(TestCase):
         ])
         self.assertEqual(mocked_run.mock_calls, [
             call(['mono', PosixPath('/ckan.exe'), 'instance', 'fake',
+                  '--game', 'KSP',
                   '--set-default', '--headless', 'dummy',
                   PosixPath('/game-instance'), '1.8.1',
                   '--MakingHistory', '1.1.0', '--BreakingGround', '1.0.0'],


### PR DESCRIPTION
## Motivation

As we advance toward the finish line of KSP2 support, we are getting closer to the point where we will need to be able to validate, review, and merge `KSP2-NetKAN` pull requests. This will require updating `xKAN-meta_testing` to support the new game.

## Problem

Only KSP1 support exists for:

- Retrieving known game versions from GitHub
- Creating a dummy game instance
- Inflating .netkans
- Validating .ckans

## Changes

Now the Action has a `game` parameter, defaulting to `KSP`, which allows the configuration file to specify how to get game versions and the value of the `--game` parameter for `netkan.exe` and `ckan instance fake` commands. This is done by creating a new `Game` abstract base class with derived classes `Ksp1` and `Ksp2`, which provide public properties specifying their short names and their known game versions. Code that needs these values is updated to get them from `Game` objects that are now deduced from the `GAME` environment variable and then passed around.

In the process of making these changes, the validator is now switched from retrieving the embedded build map, which has been renamed to `builds-ksp.json` in KSP-CKAN/CKAN#3797, to using the remote build maps, which are not subject to naming collisions because they're in separate repos.

- [x] **Note that KSP-CKAN/CKAN#3811 must be merged first for the `--game` parameter to be available everywhere it's needed!**
