### PR TITLE
Quote filename in `ckan prompt` script

### DIFF
--- a/ckan_meta_tester/ckan_install_template.txt
+++ b/ckan_meta_tester/ckan_install_template.txt
@@ -1,4 +1,4 @@
-install -c $ckanfile --headless
+install --headless -c "$ckanfile"
 list --porcelain
 show --with-versions $identifier
 remove $identifier --headless


### PR DESCRIPTION
This is a continuation of KSP-CKAN/CKAN#3889.
The metadata validator now puts quotes around the .ckan filename in case it contains spaces.

I'll probably self-review this since it's small and mostly a back-end thing.
