### PR TITLE
Suppress PR body warning without a PR

### DIFF
--- a/ckan_meta_tester/__init__.py
+++ b/ckan_meta_tester/__init__.py
@@ -2,8 +2,6 @@ import sys
 import logging
 from os import environ
 from typing import Optional
-from urllib.parse import urlparse
-import requests
 from exitstatus import ExitStatus
 
 from .ckan_meta_tester import CkanMetaTester
@@ -22,27 +20,7 @@ def test_metadata() -> None:
                         environ.get('INPUT_GAME', 'KSP'))
     sys.exit(ExitStatus.success
              if ex.test_metadata(environ.get('INPUT_SOURCE', 'netkans'),
-                                 get_pr_body(github_token, environ.get('INPUT_PULL_REQUEST_URL')),
+                                 environ.get('INPUT_PULL_REQUEST_URL'),
                                  github_token,
                                  environ.get('INPUT_DIFF_META_ROOT'))
              else ExitStatus.failure)
-
-
-def get_pr_body(github_token: Optional[str], pr_url: Optional[str]) -> str:
-    # Get PR body text
-    if pr_url:
-        headers = { 'Accept': 'application/vnd.github.v3.raw+json' }
-        parsed_pr_url = urlparse(pr_url)
-        if github_token:
-            if parsed_pr_url.scheme == 'https' and parsed_pr_url.netloc == 'api.github.com' \
-                    and parsed_pr_url.path.startswith('/repos/'):
-                headers['Authorization'] = f'token {github_token}'
-            else:
-                logging.warning('Invalid pull request url, omitting Authorization header')
-
-        resp = requests.get(pr_url, headers=headers, timeout=30)
-        if resp.ok:
-            # If the PR has an empty body, 'body' is set to None, not the empty string
-            return resp.json().get('body') or ''
-        logging.warning(resp.text)
-    return ''


### PR DESCRIPTION
## Problem

Currently when the metadata validator runs without a pull request (e.g., when a change is merged to the main branch), it always raises the empty PR body warning:

https://github.com/KSP-CKAN/CKAN-meta/actions/runs/5977643464/job/16218050128

![image](https://github.com/KSP-CKAN/xKAN-meta_testing/assets/1559108/94dec3ba-8866-4ee9-8878-799351e297eb)

## Cause

The absence of a pull request sets the `pr_body` to the empty string, just like if there's a pull request with an empty body, and there's no further logic to distinguish the two cases.

## Changes

Now if we lack a URL for the PR body, we set `pr_body` to `None`, which now suppresses the warning.

I'll probably self-review this.
