### PR TITLE
Strip KSP2 build IDs, multi-game for DLC

### DIFF
--- a/ckan_meta_tester/dummy_game_instance.py
+++ b/ckan_meta_tester/dummy_game_instance.py
@@ -10,10 +10,7 @@ from .game_version import GameVersion
 
 
 class DummyGameInstance:
-
     SAVED_REGISTRY=Path('/tmp/registry.json')
-    MAKING_HISTORY_VERSION=GameVersion('1.4.1')
-    BREAKING_GROUND_VERSION=GameVersion('1.7.1')
 
     def __init__(self, where: Path, ckan_exe: Path, addl_repo: Path, main_ver: GameVersion, other_versions: List[GameVersion], cache_path: Path, game: Game) -> None:
         self.where = where
@@ -36,7 +33,7 @@ class DummyGameInstance:
              '--game', self.game.short_name,
              '--set-default', '--headless',
              'dummy', self.where, str(self.main_ver),
-             *self._available_dlcs(self.main_ver)],
+             *self.game.dlc_cmdline_flags(self.main_ver)],
             capture_output=self.capture)
         for ver in self.other_versions:
             logging.debug('Setting version %s compatible', ver)
@@ -65,12 +62,6 @@ class DummyGameInstance:
             logging.debug('Saving registry to %s', self.SAVED_REGISTRY)
         logging.debug('Dummy instance is ready')
         return self
-
-    def _available_dlcs(self, ver: GameVersion) -> List[str]:
-        return [
-            *(['--MakingHistory',  '1.1.0'] if ver >= self.MAKING_HISTORY_VERSION  else []),
-            *(['--BreakingGround', '1.0.0'] if ver >= self.BREAKING_GROUND_VERSION else [])
-        ]
 
     def __exit__(self, exc_type: Type[BaseException],
                  exc_value: BaseException, traceback: TracebackType) -> None:


### PR DESCRIPTION
## Problem

In KSP-CKAN/KSP2-NetKAN#125 we are updating some KSP2 mods with out of date compatibility for the first time, and the install step is failing with "Module XYZ 1.2.3 required but it is not listed in the index, or not available for your version of KSP2".

## Cause

I think this is an issue of the formatting of the game versions. The spec requires game versions to have only 1–3 pieces, not 4, so all KSP2 mods obey this (see KSP-CKAN/CKAN#3969 for another recently addressed complication). But the KSP2 builds JSON file contains 4 pieces, and the meta tester is passing all 4 pieces to `ckan compat add`. I think this makes them not match the modules, so it's behaving as if the compatibility isn't being set.

## Changes

Now the build ID is stripped from KSP2's game versions.

While working on this I noticed that the DLC command line flags are passed based solely on the game version, not the game itself, so in theory KSP1's DLC flags could be passed for KSP2 if its version numbers get high enough. Now this is moved to `Game.dlc_cmdline_flags` and overridden in `Ksp1`, so KSP1 DLC will only be set up for KSP1.
