### PR TITLE
Skip install step when metadata is unchanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ jobs:
 
 ## See also
 
-Validate your KSP-AVC .version files with https://github.com/DasSkelett/AVC-VersionFileValidator !
+Validate your KSP-AVC .version files with <https://github.com/DasSkelett/AVC-VersionFileValidator>!
 
 ## Contributions
 

--- a/ckan_meta_tester/ckan_meta_tester.py
+++ b/ckan_meta_tester/ckan_meta_tester.py
@@ -189,6 +189,10 @@ class CkanMetaTester:
         if meta_repo is not None:
             diff = ckan.find_diff(meta_repo)
             if diff is not None:
+                if len(diff) == 0:
+                    print(f'::notice file={orig_file}::Diff empty for {ckan.name} {ckan.version}, skipping install',
+                          flush=True)
+                    return True
                 with LogGroup(f'Diffing {ckan.name} {ckan.version}'):
                     print(diff, end='', flush=True)
         with LogGroup(f'Installing {ckan.name} {ckan.version}'):

--- a/tests/dummy_game_instance.py
+++ b/tests/dummy_game_instance.py
@@ -2,7 +2,6 @@ from pathlib import Path, PosixPath
 import unittest.util
 from unittest import TestCase
 from unittest.mock import Mock, patch, call
-from tempfile import TemporaryDirectory, TemporaryFile
 
 from ckan_meta_tester.game import Game
 from ckan_meta_tester.game_version import GameVersion
@@ -26,7 +25,7 @@ class TestDummyGameInstance(TestCase):
         mocked_run: Mock) -> None:
 
         # Arrange
-        unittest.util._MAX_LENGTH=999999999 # :snake:
+        unittest.util._MAX_LENGTH=999999999 # type: ignore # pylint: disable=protected-access
 
         # Act
         with DummyGameInstance(


### PR DESCRIPTION
## Motivation

KSP-CKAN/NetKAN#10308 is changing 177 netkans in a way that should have no impact on their inflated metadata (with a few exceptions where `x_via: Automated SpaceDock CKAN submission` is being removed). This over an hour to validate, partly because it ran the full validation for every mod, including installing it and its dependencies.

When a .ckan file exactly matches what we already have for that mod release in the metadata repo, it will install the same as before. We have a `diff` step already, but we simply print it regardless of what it is and then proceed to the install.

## Changes

Now if a diff is empty, we announce it and skip the install step. This will make no-op netkan changes validate more quickly.
